### PR TITLE
Add coloring support for physically placed mem regions

### DIFF
--- a/src/core/inc/platform.h
+++ b/src/core/inc/platform.h
@@ -26,6 +26,8 @@ struct mem_region {
 
     int place_phys;
     uint64_t phys;
+
+    int colored;
 };
 
 struct dev_region {

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -113,6 +113,8 @@ void vm_map_mem_region(vm_t* vm, struct mem_region* reg)
 
     if (reg->place_phys) {
         ppages_t pa_reg = mem_ppages_get(reg->phys, n);
+        if(reg->colored)
+            pa_reg.colors = vm->as.colors;
         mem_map(&vm->as, va, &pa_reg, n, PTE_VM_FLAGS);
     } else {
         mem_map(&vm->as, va, NULL, n, PTE_VM_FLAGS);


### PR DESCRIPTION
This PR enables coloring for physically placed mem regions in the configuration by a flag (mem_region.colored). If set to true, a physically placed mem region will be colored according to the vm's colors. If set to false or omitted, it changes nothing.

Use case:
System memories like on chip memory (OCM on Xilinx ZCU102) to which the access should be cache colored.