### PR TITLE
Allow config relative binary paths and configs placed outside of the …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ cpu_arch_dir=$(src_dir)/arch
 lib_dir=$(src_dir)/lib
 core_dir=$(src_dir)/core
 platforms_dir=$(src_dir)/platform
-configs_dir=$(cur_dir)/configs
+configs_dir?=$(cur_dir)/configs
 config:=$(configs_dir)/$(CONFIG)/$(CONFIG).bin
 
 ifeq ($(CONFIG_BUILTIN), y)

--- a/configs/configs.mk
+++ b/configs/configs.mk
@@ -37,13 +37,13 @@ config: $(CONFIG_BLOB).bin
 $(CONFIG_DEP): $(CONFIG_SRC)
 	@$(cc) $(cppflags) -S $(patsubst %.d, %.c, $@) -o temp.S
 	@grep ".incbin" temp.S > $(patsubst %.d, %.S, $@) 
-	@$(as) -MD $@ $(patsubst %.d, %.S, $@)  -o $(patsubst %.d, %.o, $@)
+	@$(as) -I$(CONFIG_DIR) -MD $@ $(patsubst %.d, %.S, $@) -o $(patsubst %.d, %.o, $@)
 	@rm temp.S $(patsubst %.d, %.S, $@)
 	@$(cc) -MM -MG -MT "$(patsubst %.d, %.o, $@) $@"  $(cppflags) $(filter %.c, $^) >> $@
 
 $(CONFIG_OBJ): $(CONFIG_SRC)
 	@echo "Compiling source	$(patsubst $(cur_dir)/%, %, $<)"
-	@$(cc) $(cflags) -c $< -o $@
+	@$(cc) -Wa,-I$(CONFIG_DIR) $(cflags) -c $< -o $@
 
 $(CONFIG_ASM): $(CONFIG_SRC)
 	@$(cc) $(cppflags) -S $< -o $@


### PR DESCRIPTION
This PR enables the specification of a repo external config folder. Also it enables specification of a relative binary path in config.c (relative to the config folder, e.g., ./image.bin => in the specified config folder).