### PR TITLE
fix(mpu): initializing sh_mem place_phys flag for 1-to-1 mapping

### DIFF
--- a/src/core/mpu/config.c
+++ b/src/core/mpu/config.c
@@ -30,5 +30,12 @@ void config_mem_prot_init(paddr_t load_addr) {
 
     }
 
-}
+    for (size_t i = 0; i < config.shmemlist_size; i++){
+        /**
+         * On MPU systems all shared memory regions must be physical
+         * regions with 1-to-1 mapping.
+         */
+        config.shmemlist[i].place_phys = true;
+    }
 
+}


### PR DESCRIPTION
This PR fixes the mapping of the shared memory.
With MPU this must have a 1-to-1 typology, as the ipc base address must be the same as the sh_mem base address

Signed-off-by: Afonso Santos <afomms@gmail.com>