### PR TITLE
Fix the printk with error negative digits display

### DIFF
--- a/src/lib/printk.c
+++ b/src/lib/printk.c
@@ -74,7 +74,7 @@ size_t vsprintk(char *buf, const char *fmt, va_list args)
                     bool keep_zeros = false;
 
                     if (!is_unsigned) {
-                        unsigned long number_signed = is_long ? va_arg(args, unsigned long) : va_arg(args, unsigned);
+                        long number_signed = is_long ? va_arg(args, long) : va_arg(args, int);
                         if (number_signed < 0) {
                             *str++ = 0x2d;
                             number_signed = -(number_signed);


### PR DESCRIPTION
The current printk has an error when processing negative print, displaying a very large value. For example, print(%d, -1) is displayed as 4294967295 because the unsigned data type is used when processing this type.

Signed-off-by: JianlongCao <caojianlong@outlook.com>