### PR TITLE
fix(aarch32): clear TE bit to take exceptions on A32 state

### DIFF
--- a/src/arch/armv8/armv8-r/aarch32/boot.S
+++ b/src/arch/armv8/armv8-r/aarch32/boot.S
@@ -112,10 +112,8 @@ skip_non_loadable:
     isb
 
     /* Enable caches and MPU */
-    mrc p15, 4, r3, c1, c0, 0 // HSCTLR
-    ldr r4, =(SCTLR_C | SCTLR_I | SCTLR_M)
-    orr r3, r3, r4
-    mcr p15, 4, r3, c1, c0, 0 // HSCTLR
+    ldr r4, =(SCTLR_RES1_AARCH32 | SCTLR_C | SCTLR_I | SCTLR_M)
+    mcr p15, 4, r4, c1, c0, 0 // HSCTLR
 
     dsb
     isb

--- a/src/arch/armv8/armv8-r/aarch64/boot.S
+++ b/src/arch/armv8/armv8-r/aarch64/boot.S
@@ -129,10 +129,8 @@ skip_non_loadable:
     isb
 
     /* Enable caches and MPU */
-    mrs x3, sctlr_el2
-    ldr x4, =(SCTLR_C | SCTLR_I | SCTLR_M)
-    orr x3, x3, x4
-    msr sctlr_el2, x3
+    ldr x4, =(SCTLR_RES1 | SCTLR_C | SCTLR_I | SCTLR_M)
+    msr sctlr_el2, x4
 
     dsb nsh
     isb

--- a/src/arch/armv8/inc/arch/sysregs.h
+++ b/src/arch/armv8/inc/arch/sysregs.h
@@ -224,6 +224,7 @@
 /* SCTLR - System Control Register */
 
 #define SCTLR_RES1 (0x30C50830)
+#define SCTLR_RES1_AARCH32 (0x30C50818)
 #define SCTLR_M (1 << 0)
 #define SCTLR_A (1 << 1)
 #define SCTLR_C (1 << 2)


### PR DESCRIPTION
This PR allows the exceptions on the EL2 to be taken on the A32 state, as the TE bit is cleared.
The reset value of the TE bit from HSCTLR is implementation defined.

Signed-off-by: Afonso Santos <afomms@gmail.com>