### PR TITLE
RISC-V ACLINT Support

### DIFF
--- a/.github/workflows/build-riscv.yaml
+++ b/.github/workflows/build-riscv.yaml
@@ -20,8 +20,13 @@ jobs:
           "PLIC",
           "APLIC",
         ]
+        ipic: [
+          "IPIC_SBI",
+          "IPIC_ACLINT",
+        ]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: make PLATFORM=${{ matrix.platform }} IRQC=${{ matrix.irqc }} CONFIG=null
+      - run: make PLATFORM=${{ matrix.platform }} IRQC=${{ matrix.irqc }} \
+            IPIC=${{ matrix.ipic }} CONFIG=null

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ gens+=$(config_def_generator) $(config_defs)
 inc_dirs+=$(config_build_dir)
 
 platform_def_generator_src:=$(scripts_dir)/platform_defs_gen.c
+platform_arch_def_generator_src:=$(wildcard $(scripts_dir)/arch/$(ARCH)/platform_defs_gen.c)
+platform_def_generator_src+=$(platform_arch_def_generator_src)
 platform_def_generator:=$(scripts_build_dir)/platform_defs_gen
 platform_defs:=$(platform_build_dir)/platform_defs_gen.h
 platform_description:=$(platform_dir)/$(platform_description)

--- a/scripts/arch/riscv/platform_defs_gen.c
+++ b/scripts/arch/riscv/platform_defs_gen.c
@@ -1,0 +1,15 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved
+ */
+
+#include <stdio.h>
+#include <platform.h>
+
+void arch_platform_defs() {
+
+    if (platform.arch.aclint_sswi.base != 0) {
+        printf("#define ACLINT_SSWI 1\n");
+    }
+
+}

--- a/scripts/platform_defs_gen.c
+++ b/scripts/platform_defs_gen.c
@@ -6,7 +6,9 @@
 #include <stdio.h>
 #include <platform.h>
 
-extern void arch_platform_defs();
+__attribute__((weak)) void arch_platform_defs(void){
+    return;
+}
 
 int main() {
 
@@ -15,6 +17,7 @@ int main() {
     if (platform.cpu_master_fixed) {
         printf("#define CPU_MASTER_FIXED (%ld)\n", platform.cpu_master);
     }
-
+    // Call arch specific platform defines generator
+    arch_platform_defs();
     return 0;
 }

--- a/src/arch/riscv/aclint.c
+++ b/src/arch/riscv/aclint.c
@@ -1,0 +1,40 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <arch/aclint.h>
+#include <cpu.h>
+#include <bao.h>
+#include <platform.h>
+
+volatile struct aclint_sswi_hw* aclint_sswi;
+
+void aclint_init()
+{
+    aclint_sswi = (void*)mem_alloc_map_dev(&cpu()->as, SEC_HYP_GLOBAL, INVALID_VA,
+        platform.arch.aclint_sswi.base, NUM_PAGES(sizeof(struct aclint_sswi_hw)));
+}
+
+void aclint_send_ipi(cpuid_t target_hart)
+{
+    cpuid_t aclint_index = aclint_plat_hart_id_to_sswi_index(target_hart);
+    if (target_hart < platform.cpu_num) {
+        aclint_sswi->setssip[aclint_index] = ACLINT_SSWI_SET_SETSSIP;
+    }
+}
+
+/**
+ * By default aclint hart index is equal to the hart identifier
+ * This may be overwritten on the platform defined code
+ */
+
+__attribute__((weak)) cpuid_t aclint_plat_sswi_index_to_hart_id(cpuid_t sswi_index)
+{
+    return sswi_index;
+}
+
+__attribute__((weak)) cpuid_t aclint_plat_hart_id_to_sswi_index(cpuid_t hart_id)
+{
+    return hart_id;
+}

--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -18,6 +18,9 @@ irqc_arch_dir=$(cpu_arch_dir)/irqc/$(IRQC_DIR)
 src_dirs+=$(irqc_arch_dir)
 
 arch-cppflags+=-DIRQC=$(IRQC)
+ifeq ($(ACLINT_PRESENT), 1)
+arch-cppflags+=-DACLINT_PRESENT
+endif
 arch-cflags = -mcmodel=medany -march=rv64g -mstrict-align
 arch-asflags =
 arch-ldflags = 

--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -18,9 +18,6 @@ irqc_arch_dir=$(cpu_arch_dir)/irqc/$(IRQC_DIR)
 src_dirs+=$(irqc_arch_dir)
 
 arch-cppflags+=-DIRQC=$(IRQC)
-ifeq ($(ACLINT_PRESENT), 1)
-arch-cppflags+=-DACLINT_PRESENT
-endif
 arch-cflags = -mcmodel=medany -march=rv64g -mstrict-align
 arch-asflags =
 arch-ldflags = 

--- a/src/arch/riscv/inc/arch/aclint.h
+++ b/src/arch/riscv/inc/arch/aclint.h
@@ -1,0 +1,28 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef ACLINT_H
+#define ACLINT_H
+
+#include <bao.h>
+#include <platform.h>
+
+#define ACLINT_SSWI_MAX_HARTS   (4095)
+#define ACLINT_SSWI_SET_SETSSIP (0x1)
+
+struct aclint_sswi_hw {
+    uint32_t setssip[ACLINT_SSWI_MAX_HARTS];
+    uint32_t res;
+} __attribute__((__packed__, aligned(PAGE_SIZE)));
+
+extern volatile struct aclint_sswi_hw* aclint_sswi;
+
+void aclint_init();
+void aclint_send_ipi(cpuid_t hart);
+
+cpuid_t aclint_plat_sswi_index_to_hart_id(cpuid_t sswi_index);
+cpuid_t aclint_plat_hart_id_to_sswi_index(cpuid_t hard_id);
+
+#endif /* ACLINT_H */

--- a/src/arch/riscv/inc/arch/interrupts.h
+++ b/src/arch/riscv/inc/arch/interrupts.h
@@ -9,18 +9,20 @@
 #include <bao.h>
 #include <irqc.h>
 
-#define PLIC           (1)
-#define APLIC          (2)
+#define PLIC             (1)
+#define APLIC            (2)
+
+#define ACLINT_PRESENT() DEFINED(ACLINT_SSWI)
 
 /**
  * In riscv, the ipi (software interrupt) and timer interrupts dont actually have an ID as their
  * are treated differently from external interrupts routed by the external interrupt controller,
  * the PLIC. Will define their ids as the ids after the maximum possible in the PLIC.
  */
-#define SOFT_INT_ID    (IRQC_MAX_INTERRUPTS + 1)
-#define TIMR_INT_ID    (IRQC_MAX_INTERRUPTS + 2)
-#define MAX_INTERRUPTS (TIMR_INT_ID + 1)
+#define SOFT_INT_ID      (IRQC_MAX_INTERRUPTS + 1)
+#define TIMR_INT_ID      (IRQC_MAX_INTERRUPTS + 2)
+#define MAX_INTERRUPTS   (TIMR_INT_ID + 1)
 
-#define IPI_CPU_MSG    SOFT_INT_ID
+#define IPI_CPU_MSG      SOFT_INT_ID
 
 #endif /* __ARCH_INTERRUPTS_H__ */

--- a/src/arch/riscv/inc/arch/platform.h
+++ b/src/arch/riscv/inc/arch/platform.h
@@ -26,6 +26,10 @@ struct arch_platform {
         unsigned mode;     // Overall IOMMU mode (Off, Bypass, DDT-lvl)
         irqid_t fq_irq_id; // Fault Queue IRQ ID (wired)
     } iommu;
+
+    struct {
+        paddr_t base; // Base address of the ACLINT supervisor software interrupts
+    } aclint_sswi;
 };
 
 #endif /* __ARCH_PLATFORM_H__ */

--- a/src/arch/riscv/interrupts.c
+++ b/src/arch/riscv/interrupts.c
@@ -14,11 +14,15 @@
 #include <vm.h>
 #include <arch/csrs.h>
 #include <fences.h>
+#include <arch/aclint.h>
 
 void interrupts_arch_init()
 {
     if (cpu()->id == CPU_MASTER) {
         irqc_init();
+        if (DEFINED(ACLINT_PRESENT)) {
+            aclint_init();
+        }
     }
 
     /* Wait for master hart to finish irqc initialization */
@@ -34,7 +38,11 @@ void interrupts_arch_init()
 
 void interrupts_arch_ipi_send(cpuid_t target_cpu, irqid_t ipi_id)
 {
-    sbi_send_ipi(1ULL << target_cpu, 0);
+    if (DEFINED(ACLINT_PRESENT)) {
+        aclint_send_ipi(target_cpu);
+    } else {
+        sbi_send_ipi(1ULL << target_cpu, 0);
+    }
 }
 
 void interrupts_arch_cpu_enable(bool en)

--- a/src/arch/riscv/interrupts.c
+++ b/src/arch/riscv/interrupts.c
@@ -20,7 +20,7 @@ void interrupts_arch_init()
 {
     if (cpu()->id == CPU_MASTER) {
         irqc_init();
-        if (DEFINED(ACLINT_PRESENT)) {
+        if (ACLINT_PRESENT()) {
             aclint_init();
         }
     }
@@ -38,7 +38,7 @@ void interrupts_arch_init()
 
 void interrupts_arch_ipi_send(cpuid_t target_cpu, irqid_t ipi_id)
 {
-    if (DEFINED(ACLINT_PRESENT)) {
+    if (ACLINT_PRESENT()) {
         aclint_send_ipi(target_cpu);
     } else {
         sbi_send_ipi(1ULL << target_cpu, 0);

--- a/src/arch/riscv/objects.mk
+++ b/src/arch/riscv/objects.mk
@@ -15,3 +15,4 @@ cpu-objs-y+=cpu.o
 cpu-objs-y+=cache.o
 cpu-objs-y+=iommu.o
 cpu-objs-y+=relocate.o
+cpu-objs-y+=aclint.o

--- a/src/platform/qemu-riscv64-virt/inc/plat/platform.h
+++ b/src/platform/qemu-riscv64-virt/inc/plat/platform.h
@@ -10,4 +10,7 @@
 
 #define CPU_EXT_SSTC 1
 
+#define IPIC_SBI     (1)
+#define IPIC_ACLINT  (2)
+
 #endif

--- a/src/platform/qemu-riscv64-virt/platform.mk
+++ b/src/platform/qemu-riscv64-virt/platform.mk
@@ -7,12 +7,14 @@ ARCH:=riscv
 CPU:=
 # Interrupt controller definition
 IRQC:=PLIC
+# Core IPIs controller
+IPIC:=IPIC_SBI
 
 drivers := sbi_uart
 
 platform_description:=virt_desc.c
 
-platform-cppflags =
+platform-cppflags =-DIPIC=$(IPIC)
 platform-cflags = 
 platform-asflags =
 platform-ldflags =

--- a/src/platform/qemu-riscv64-virt/virt_desc.c
+++ b/src/platform/qemu-riscv64-virt/virt_desc.c
@@ -26,6 +26,8 @@ struct platform platform = {
 #else
 #error "unknown IRQC type " IRQC
 #endif
+        // Disable ACLINT by default
+        .aclint_sswi.base = 0
     },
 
 };

--- a/src/platform/qemu-riscv64-virt/virt_desc.c
+++ b/src/platform/qemu-riscv64-virt/virt_desc.c
@@ -26,8 +26,13 @@ struct platform platform = {
 #else
 #error "unknown IRQC type " IRQC
 #endif
-        // Disable ACLINT by default
-        .aclint_sswi.base = 0
+#if (IPIC == IPIC_SBI)
+        .aclint_sswi.base = 0,
+#elif (IPIC == IPIC_ACLINT)
+        .aclint_sswi.base = 0x2f00000,
+#else
+#error "unknown IPIC type " IPIC
+#endif
     },
 
 };


### PR DESCRIPTION
Features:
- IPIs sent via ACLINT instead of SBI ECALLs

Notes:
Linux -> https://github.com/avpatel/linux/tree/riscv_aclint_v5
QEMU -> 7.2 with flag _-M aclint=on_ 