### PR TITLE
Update CPU master selection

### DIFF
--- a/scripts/platform_defs_gen.c
+++ b/scripts/platform_defs_gen.c
@@ -12,6 +12,9 @@ int main() {
 
     printf("#define PLAT_CPU_NUM (%ld)\n", platform.cpu_num);
     printf("#define PLAT_BASE_ADDR (0x%lx)\n", platform.regions[0].base);
+    if (platform.cpu_master_fixed) {
+        printf("#define CPU_MASTER_FIXED (%ld)\n", platform.cpu_master);
+    }
 
     return 0;
 }

--- a/src/arch/armv8/aarch32/boot.S
+++ b/src/arch/armv8/aarch32/boot.S
@@ -70,18 +70,18 @@ _master_set:
     .4byte 0
 .popsection
 /**
- * Setting CPU_MASTER by lottery, the first cpu to atomically set _master_set,
- * becomes the cpu master. As a result r9 should is set to !is_cpu_master.
+ * If the cpu master is not fixed, for setting it, we assume only one cpu is
+ * initially activated which later will turn on all the others. Therefore, there
+ * is no concurrency when setting CPU_MASTER and no atomic operations are needed.
+ * x9 should if set !is_cpu_master.
  */
     mov	r5, #1
     get_phys_addr r3, r4, _master_set
 _set_master_cpu:
-    ldaex r9, [r3]
+    ldr r9, [r3]
     cmp r9, #0
     bne 1f
-    stlex r9, r5, [r3]
-    cmp r9, #0
-    bne _set_master_cpu
+    str r5, [r3]
     get_phys_addr r3, r4, CPU_MASTER
     str r0, [r3]
 1:

--- a/src/arch/armv8/aarch32/boot.S
+++ b/src/arch/armv8/aarch32/boot.S
@@ -65,16 +65,23 @@ _reset_handler:
     get_phys_addr r3, r4, _hyp_vector_table
     mcr p15, 4, r3, c12, c0, 0 // write HVBAR
 
-.pushsection .data
-_master_set:
-    .4byte 0
-.popsection
+/* Setting r9 should if set !is_cpu_master */
+#if defined(CPU_MASTER_FIXED)
+   mov r3, #CPU_MASTER_FIXED
+   cmp r0, r3
+   movne r9, #1
+   cmp r9, #0
+   bne 1f
+#else
 /**
  * If the cpu master is not fixed, for setting it, we assume only one cpu is
  * initially activated which later will turn on all the others. Therefore, there
  * is no concurrency when setting CPU_MASTER and no atomic operations are needed.
- * x9 should if set !is_cpu_master.
  */
+ .pushsection .data
+_master_set:
+    .4byte 0
+.popsection
     mov	r5, #1
     get_phys_addr r3, r4, _master_set
 _set_master_cpu:
@@ -82,6 +89,7 @@ _set_master_cpu:
     cmp r9, #0
     bne 1f
     str r5, [r3]
+#endif
     get_phys_addr r3, r4, CPU_MASTER
     str r0, [r3]
 1:

--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -85,25 +85,32 @@ _reset_handler:
 	and x0, x0, #0xff
 	add x0, x0, x7
 
-.pushsection .data
-_master_set:
-	.8byte 	0
-.popsection
+/* Setting x9 should if set !is_cpu_master */
+#if defined(CPU_MASTER_FIXED)
+   mov x3, CPU_MASTER_FIXED
+   cmp x0, x3
+   cset x9, ne
+   cbnz x9, 1f
+#else
 /**
  * If the cpu master is not fixed, for setting it, we assume only one cpu is
  * initially activated which later will turn on all the others. Therefore, there
  * is no concurrency when setting CPU_MASTER and no atomic operations are needed.
- * x9 should if set !is_cpu_master.
  */
+ .pushsection .data
+_master_set:
+	.8byte 	0
+.popsection
     mov x5, #1
     adr	x3, _master_set
 _set_master_cpu:
 	ldr w9, [x3]
 	cbnz w9, 1f
 	str w5, [x3]
+#endif
 	adr x3, CPU_MASTER
 	str x0, [x3]
-1: 
+1:
 
 	/** 
 	 * TODO: bring the system to a well known state. This includes disabling 

--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -90,16 +90,17 @@ _master_set:
 	.8byte 	0
 .popsection
 /**
- * Setting CPU_MASTER by lottery, the first cpu to atomically set _master_set,
- * becomes the cpu master. As a result x9 should is set to !is_cpu_master.
+ * If the cpu master is not fixed, for setting it, we assume only one cpu is
+ * initially activated which later will turn on all the others. Therefore, there
+ * is no concurrency when setting CPU_MASTER and no atomic operations are needed.
+ * x9 should if set !is_cpu_master.
  */
     mov x5, #1
     adr	x3, _master_set
 _set_master_cpu:
-	ldaxr w9, [x3]
+	ldr w9, [x3]
 	cbnz w9, 1f
-	stlxr w9, w5, [x3]
-	cbnz w9, _set_master_cpu
+	str w5, [x3]
 	adr x3, CPU_MASTER
 	str x0, [x3]
 1: 

--- a/src/arch/riscv/boot.S
+++ b/src/arch/riscv/boot.S
@@ -115,10 +115,18 @@ _reset_handler:
     csrw   sip, zero
     csrw   satp, zero 
 
-    /**
-     * The first hart to grab the lock is CPU_MASTER
-     */
 
+#if defined(CPU_MASTER_FIXED)
+/**
+ * All cpus set the CPU_MASTER with the same value to avoid synchronization.    
+ */
+    la      t0, CPU_MASTER
+    li      t1, CPU_MASTER_FIXED
+    sd      t1, 0(t0)
+#else
+/**
+ * The first hart to grab the lock is CPU_MASTER.
+ */
 .pushsection .data
 _boot_lock:
     .4byte 0
@@ -133,6 +141,7 @@ _boot_lock:
     la      t0, CPU_MASTER
     sd      a0, 0(t0)
 2:
+#endif
 
     /* Setup bootstrap page tables. Assuming sv39 support. */ 
 

--- a/src/core/inc/platform.h
+++ b/src/core/inc/platform.h
@@ -15,6 +15,8 @@
 
 struct platform {
     size_t cpu_num;
+    bool    cpu_master_fixed;
+    cpuid_t cpu_master;
 
     size_t region_num;
     struct mem_region *regions;

--- a/src/platform/fvp-r/fvpr_desc.c
+++ b/src/platform/fvp-r/fvpr_desc.c
@@ -8,6 +8,9 @@
 struct platform platform = {
 
     .cpu_num = 4,
+    .cpu_master_fixed = true,
+    .cpu_master = 0,
+
     .region_num = 1,
     .regions =  (struct mem_region[]) {
         {


### PR DESCRIPTION
Most platforms start with only a single CPU which is then responsible for waking up others, but this is not the case for the newer Arm cortex-R where every CPU wakes up in unison. Because of this, Bao employed a lottery that made use of atomic load/store exclusive (arm) and load-acquire/store-conditional (riscv) instructions to select the master CPU that will subsequently coordinate system initialization. This happens right at the start of execution before MMU/MPU is enabled. This is a problem because the used atomic instructions might only work with translation enabled in Arm platforms or if the used atomic data is part of a non-reservable PMA region in RISC-V, which could result in multiple CPUs assuming they were the boot master.

To circumvent this problem, this PR first reverts the lottery selection to the assumption that only one CPU wakes first, therefore removing the need for synchronization, and then introduces a facility that alternatively allows a platform to statically define its master CPU.