### PR TITLE
fix(hypercall/risc-v): don't exclude A0 register from args retrieval in hypercall()

### DIFF
--- a/src/arch/armv8/inc/arch/hypercall.h
+++ b/src/arch/armv8/inc/arch/hypercall.h
@@ -6,6 +6,6 @@
 #ifndef ARCH_HYPERCALL_H
 #define ARCH_HYPERCALL_H
 
-#define HYPCALL_ARG_REG(ARG)  (ARG)
+#define HYPCALL_ARG_REG(ARG)  ((ARG) + 1)
 
 #endif /* ARCH_HYPERCALL_H */

--- a/src/core/hypercall.c
+++ b/src/core/hypercall.c
@@ -11,13 +11,13 @@
 long int hypercall(unsigned long id) {
     long int ret = -HC_E_INVAL_ID;
 
-    unsigned long arg1 = vcpu_readreg(cpu()->vcpu, HYPCALL_ARG_REG(1));
-    unsigned long arg2 = vcpu_readreg(cpu()->vcpu, HYPCALL_ARG_REG(2));
-    unsigned long arg3 = vcpu_readreg(cpu()->vcpu, HYPCALL_ARG_REG(3));
+    unsigned long ipc_id = vcpu_readreg(cpu()->vcpu, HYPCALL_ARG_REG(0));
+    unsigned long arg1   = vcpu_readreg(cpu()->vcpu, HYPCALL_ARG_REG(1));
+    unsigned long arg2   = vcpu_readreg(cpu()->vcpu, HYPCALL_ARG_REG(2));
 
     switch(id){
         case HC_IPC:
-            ret = ipc_hypercall(arg1, arg2, arg3);
+            ret = ipc_hypercall(ipc_id, arg1, arg2);
         break;
         default:
             WARNING("Unknown hypercall id %d", id);


### PR DESCRIPTION
The current multi-arch implementation does not include RISC-V A0 register when running Bao on top of a RISC-V arch. A0 contains the ipc_id and it is not passed to the ipc_ipercall() function causing possible errors due to the right argument missing.

To fix this, the HYPCALL_ARG_REG(ARG) now starts with offset 0 (now A0 is the first register considered for RISC-V), but then the same interface function must be changed for ARM (by adding +1 to the updated offset).

To improve readability and avoid misunderstandings, the argument retrieved by A0 in RISC-V and by X1 in ARM is now called ipc_id.