### PR TITLE
Bug fix barrier: missing isb()

### DIFF
--- a/src/arch/armv8/mem.c
+++ b/src/arch/armv8/mem.c
@@ -49,6 +49,7 @@ bool mem_translate(addr_space_t* as, void* va, uint64_t* pa)
     else
         asm volatile("AT S12E1W, %0" ::"r"(va));
 
+    asm volatile("isb" ::: "memory");
     par = MRS(PAR_EL1);
     MSR(PAR_EL1, par_saved);
     if (par & PAR_F) {


### PR DESCRIPTION
Spec says: "Where an instruction results in an update to a System register, as is the case with the AT * address translation
instructions, explicit synchronization must be performed before the result is guaranteed to be visible to subsequent
direct reads of the PAR_EL1."

Signed-off-by: JorgeMVP <jorgepereira89@gmail.com>