### PR TITLE
Typos fixing and trailing whitespace removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ scripts_dir:=$(cur_dir)/scripts
 src_dirs:=
 
 #Plataform must be defined excpet for clean target
-ifeq ($(PLATFORM),) 
+ifeq ($(PLATFORM),)
 ifneq ($(MAKECMDGOALS), clean)
  $(error Target platform argument (PLATFORM) not specified)
 endif
@@ -177,11 +177,11 @@ override CFLAGS+=-O$(OPTIMIZATIONS) -Wall -Werror -ffreestanding -std=gnu11 \
 override ASFLAGS+=$(CFLAGS) $(arch-asflags) $(platform-asflags)
 override LDFLAGS+=-build-id=none -nostdlib --fatal-warnings \
 	-z common-page-size=$(PAGE_SIZE) -z max-page-size=$(PAGE_SIZE) \
-	$(arch-ldflags) $(plattform-ldflags)
+	$(arch-ldflags) $(platform-ldflags)
 
 .PHONY: all
 all: $(targets-y)
-	
+
 $(bin_dir)/$(PROJECT_NAME).elf: $(gens) $(objs-y) $(ld_script_temp)
 	@echo "Linking			$(patsubst $(cur_dir)/%, %, $@)"
 	@$(ld) $(LDFLAGS) -T$(ld_script_temp) $(objs-y) -o $@
@@ -202,14 +202,14 @@ ifeq (, $(findstring $(MAKECMDGOALS), clean $(submakes)))
 -include $(deps)
 endif
 
-$(ld_script_temp).d: $(ld_script) 
+$(ld_script_temp).d: $(ld_script)
 	@echo "Creating dependency	$(patsubst $(cur_dir)/%, %, $<)"
 	@$(cc) -x assembler-with-cpp  -MM -MT "$(ld_script_temp) $@" \
 		$(addprefix -I, $(inc_dirs))  $< > $@
 
 $(build_dir)/%.d : $(src_dir)/%.[c,S]
 	@echo "Creating dependency	$(patsubst $(cur_dir)/%, %, $<)"
-	@$(cc) -MM -MG -MT "$(patsubst %.d, %.o, $@) $@"  $(CPPFLAGS) $< > $@	
+	@$(cc) -MM -MG -MT "$(patsubst %.d, %.o, $@) $@"  $(CPPFLAGS) $< > $@
 
 $(objs-y):
 	@echo "Compiling source	$(patsubst $(cur_dir)/%, %, $<)"
@@ -234,7 +234,7 @@ $(asm_defs_hdr): $(asm_defs_src)
 $(asm_defs_hdr).d: $(asm_defs_src)
 	@echo "Creating dependency	$(patsubst $(cur_dir)/%, %,\
 		 $(patsubst %.d,%, $@))"
-	@$(cc) -MM -MT "$(patsubst %.d,%, $@)" $(addprefix -I, $(inc_dirs)) $< > $@	
+	@$(cc) -MM -MT "$(patsubst %.d,%, $@)" $(addprefix -I, $(inc_dirs)) $< > $@
 endif
 
 $(config_dep): $(config_src)

--- a/src/core/inc/types.h
+++ b/src/core/inc/types.h
@@ -38,7 +38,7 @@ typedef unsigned irqid_t;
 typedef unsigned streamid_t;
 
 typedef enum AS_SEC {
-    /*--- VM AS SECTIONS -----*/
+    /*--- HYP AS SECTIONS -----*/
     SEC_HYP_GLOBAL = 0,
     SEC_HYP_IMAGE,
     SEC_HYP_PRIVATE,

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -56,19 +56,19 @@ static void ipc_notify(size_t shmem_id, size_t event_id) {
 static void ipc_handler(uint32_t event, uint64_t data){
     union ipc_msg_data ipc_data = { .raw = data };
     switch(event){
-        case IPC_NOTIFY: 
+        case IPC_NOTIFY:
             ipc_notify(ipc_data.shmem_id, ipc_data.event_id);
         break;
     }
 }
-CPU_MSG_HANDLER(ipc_handler, IPC_CPUSMG_ID);
+CPU_MSG_HANDLER(ipc_handler, IPC_CPUMSG_ID);
 
-unsigned long ipc_hypercall(unsigned long ipc_id, unsigned long ipc_event, 
+unsigned long ipc_hypercall(unsigned long ipc_id, unsigned long ipc_event,
                                                 unsigned long arg2)
 {
     unsigned long ret = -HC_E_SUCCESS;
 
-    struct shmem *shmem = NULL; 
+    struct shmem *shmem = NULL;
     bool valid_ipc_obj = ipc_id < cpu()->vcpu->vm->ipc_num;
     if(valid_ipc_obj) {
         shmem = ipc_get_shmem(cpu()->vcpu->vm->ipcs[ipc_id].shmem_id);
@@ -83,7 +83,7 @@ unsigned long ipc_hypercall(unsigned long ipc_id, unsigned long ipc_event,
             .shmem_id = cpu()->vcpu->vm->ipcs[ipc_id].shmem_id,
             .event_id = ipc_event,
         };
-        struct cpu_msg msg = {IPC_CPUSMG_ID, IPC_NOTIFY, data.raw};
+        struct cpu_msg msg = {IPC_CPUMSG_ID, IPC_NOTIFY, data.raw};
 
         for (size_t i = 0; i < platform.cpu_num; i++) {
             if (ipc_cpu_masters & (1ULL << i)) {


### PR DESCRIPTION
This PR is mainly for fixing some of the "relevant typos" (and related whitespaces) in the code base.

The important one is the one inside the Makefile which also avoid a possible bug.
The others are more related to the comprehension and "raw documentation" of the code.