### PR TITLE
fix(lib/bitmap): count consecutive limit check

### DIFF
--- a/src/lib/bitmap.c
+++ b/src/lib/bitmap.c
@@ -42,12 +42,12 @@ size_t bitmap_count_consecutive(bitmap_t* map, size_t size, size_t start,
     }
 
     mask = set ? ~0 : 0;
-    while (!(map[pos/BITMAP_GRANULE_LEN] ^ mask) && (count < n)) {
+    while ((pos < size) && !(map[pos/BITMAP_GRANULE_LEN] ^ mask) && (count < n)) {
         count += BITMAP_GRANULE_LEN;
         pos += BITMAP_GRANULE_LEN;
     }
 
-    while ((!!bitmap_get(map, pos) == set) && (count < n)) {
+    while ((pos < size) && (!!bitmap_get(map, pos) == set) && (count < n)) {
         count++;
         pos += 1;
     }


### PR DESCRIPTION
This PR fixes the stop condition on the _bitmap_count_consecutive_ function.
The fix assures that the cycle finishes before accessing one position after the bitmap size
