### PR TITLE
fix(riscv/vm): fix vplic_init call 

### DIFF
--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -21,7 +21,7 @@ void vm_arch_init(struct vm *vm, const struct vm_config *config)
 
     CSRW(CSR_HGATP, hgatp);
 
-    vplic_init(vm, platform.arch.plic_base);
+    vplic_init(vm, config->platform.arch.plic_base);
 }
 
 void vcpu_arch_init(struct vcpu *vcpu, struct vm *vm) {


### PR DESCRIPTION
Fix vplic_init call in riscv/vm.c to initialize the vplic with config's plic base instead platform's.

I have tested it in QEMU running Linux to ensure that the modifications perform as intended. To guarantee this, I configured the Linux VM to access the PLIC at address 0xd000000 instead of the physical address 0xc000000. With these modifications, it worked successfully.