### PR TITLE
fix(*/vm.h): change irq type in irq inject funcs

### DIFF
--- a/src/arch/armv8/inc/arch/vm.h
+++ b/src/arch/armv8/inc/arch/vm.h
@@ -55,12 +55,12 @@ bool vcpu_arch_profile_on(struct vcpu* vcpu);
 void vcpu_arch_profile_init(struct vcpu* vcpu, struct vm* vm);
 void vcpu_subarch_reset(struct vcpu* vcpu);
 
-static inline void vcpu_arch_inject_hw_irq(struct vcpu* vcpu, uint64_t id)
+static inline void vcpu_arch_inject_hw_irq(struct vcpu* vcpu, irqid_t id)
 {
     vgic_inject_hw(vcpu, id);
 }
 
-static inline void vcpu_arch_inject_irq(struct vcpu* vcpu, uint64_t id)
+static inline void vcpu_arch_inject_irq(struct vcpu* vcpu, irqid_t id)
 {
     vgic_inject(vcpu, id, 0);
 }

--- a/src/arch/riscv/inc/arch/vm.h
+++ b/src/arch/riscv/inc/arch/vm.h
@@ -111,12 +111,12 @@ struct arch_regs {
 
 void vcpu_arch_entry();
 
-static inline void vcpu_arch_inject_hw_irq(struct vcpu *vcpu, uint64_t id)
+static inline void vcpu_arch_inject_hw_irq(struct vcpu *vcpu, irqid_t id)
 {
     vplic_inject(vcpu, id);
 }
 
-static inline void vcpu_arch_inject_irq(struct vcpu *vcpu, uint64_t id)
+static inline void vcpu_arch_inject_irq(struct vcpu *vcpu, irqid_t id)
 {
     vplic_inject(vcpu, id);
 }


### PR DESCRIPTION
I believe that the correct type for interrupt id here should be irqid_t.  