### PR TITLE
fix(armv8/aarch64): assert 'cluster_num' type size in asm code 

### DIFF
--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -76,8 +76,11 @@ _reset_handler:
 1:
 	cmp x5, x3
 	b.ge	2f
-	ldrb w6, [x4]
-	add x4, x4, #1
+#if PLAT_CLUSTERS_CORES_NUM_SIZE != 8
+#error "struct platform cluster core_num field type size is not 8"
+#endif
+	ldr w6, [x4]
+	add x4, x4, #PLAT_CLUSTERS_CORES_NUM_SIZE
 	add x5, x5, #1
 	add x7, x7, x6
 	b 	1b

--- a/src/arch/armv8/asm_defs.c
+++ b/src/arch/armv8/asm_defs.c
@@ -34,4 +34,5 @@ void platform_defines()
     DEFINE_OFFSET(PLAT_ARCH_OFF, struct platform, arch);
     DEFINE_OFFSET(PLAT_ARCH_CLUSTERS_OFF, struct arch_platform, clusters);
     DEFINE_OFFSET(PLAT_CLUSTERS_CORES_NUM_OFF, struct clusters, core_num);
+    DEFINE_SIZE(PLAT_CLUSTERS_CORES_NUM_SIZE, ((struct clusters*)NULL)->core_num[0]); 
 }


### PR DESCRIPTION
In armv8, the platform's cluster information is used in the boot assembly code to linearize the CPU ID from Arm's hierarchical "affinity ID". However,  the code assumed byte-width entries in the `cluster_num` array, which were, in fact, of `size_t` type, which is a machine-word-sized type. In the past, the type was indeed `uint8_t` but was changed recently.

This PR fixes this issue and generates a macro with the type size used by a pre-processor assert to prevent this issue from resurfacing if the type is changed again in the future.