### PR TITLE
fix(core/ipc): fix ipc interrupt delivery

### DIFF
--- a/src/core/inc/ipc.h
+++ b/src/core/inc/ipc.h
@@ -15,6 +15,7 @@ struct ipc {
     size_t shmem_id;
     size_t interrupt_num;
     irqid_t *interrupts;
+    size_t interrupt_offset;
 };
 
 struct vm_config;

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -49,7 +49,7 @@ static void ipc_notify(size_t shmem_id, size_t event_id) {
     struct ipc* ipc_obj = ipc_find_by_shmemid(cpu()->vcpu->vm, shmem_id);
     if(ipc_obj != NULL && event_id < ipc_obj->interrupt_num) {
         irqid_t irq_id = ipc_obj->interrupts[event_id];
-        vcpu_inject_hw_irq(cpu()->vcpu, irq_id);
+        vcpu_inject_hw_irq(cpu()->vcpu, irq_id + ipc_obj->interrupt_offset);
     }
 }
 


### PR DESCRIPTION
Add interrupt_offset to struct ipc for offsetting the IRQ number before IPC interrupt injection into guest.

Take Linux guest as an example, GIC driver (driver/irqchip/irq-gic-v3.c) adds 32 to the SPI's IRQ number. Thus, to successfully deliver the IPC interrupt to the guest, an offset is added to the IRQ number.

For example, below code snippet defines the ipc for Linux VM and assigns 52 as the IRQ number. However, the actual IRQ number in Linux is 84. By offsetting 32 to the IRQ number, the IPC interrupt can be delivered.

                .ipc_num = 1,
                .ipcs = (struct ipc[]) {
                    {
                        .base = 0xf0000000,
                        .size = 0x00010000,
                        .shmem_id = 0,
                        .interrupt_num = 1,
                        .interrupts = (irqid_t[]) {52},
                        .interrupt_offset = 32
                    }
                },

On FreeRTOS or Zephyr, the offset is not needed.