### PR TITLE
Fix forced integer to bitmap casts

### DIFF
--- a/src/arch/armv8/gicv2.c
+++ b/src/arch/armv8/gicv2.c
@@ -40,8 +40,7 @@ static inline void gicc_init()
     gich->HCR |= GICH_HCR_LRENPIE_BIT;
     
     uint32_t sgi_targets = gicd->ITARGETSR[0] & BIT32_MASK(0, GIC_TARGET_BITS);
-    ssize_t gic_cpu_id = 
-        bitmap_find_nth((bitmap_t*)&sgi_targets, GIC_TARGET_BITS, 1, 0, true);
+    ssize_t gic_cpu_id = bit32_ffs(sgi_targets);
     if(gic_cpu_id < 0) {
         ERROR("cant find gic cpu id");
     }

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -1006,7 +1006,7 @@ struct vgic_int* vgic_highest_prio_spilled(struct vcpu *vcpu,
 
 static void vgic_refill_lrs(struct vcpu *vcpu, bool npie) {
     uint64_t elrsr = gich_get_elrsr();
-    ssize_t  lr_ind = bitmap_find_nth((bitmap_t*)&elrsr, NUM_LRS, 1, 0, true);
+    ssize_t  lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
     unsigned flags = npie ? PEND : ACT | PEND;
     spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
     while(lr_ind >= 0) {
@@ -1028,7 +1028,7 @@ static void vgic_refill_lrs(struct vcpu *vcpu, bool npie) {
         }
         flags = ACT | PEND;
         elrsr = gich_get_elrsr();
-        lr_ind = bitmap_find_nth((bitmap_t*)&elrsr, NUM_LRS, 1, 0, true);
+        lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
     }
     spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
 }
@@ -1059,7 +1059,7 @@ static void vgic_eoir_highest_spilled_active(struct vcpu *vcpu)
 void vgic_handle_trapped_eoir(struct vcpu *vcpu)
 {
     uint64_t eisr = gich_get_eisr();
-    int64_t lr_ind = bitmap_find_nth((bitmap_t*)&eisr, NUM_LRS, 1, 0, true);
+    int64_t lr_ind = bit64_ffs(eisr & BIT64_MASK(0, NUM_LRS));
     while (lr_ind >= 0) {
         unsigned long lr_val = gich_read_lr(lr_ind);
         gich_write_lr(lr_ind, 0);
@@ -1077,7 +1077,7 @@ void vgic_handle_trapped_eoir(struct vcpu *vcpu)
         }
         spin_unlock(&interrupt->lock);
         eisr = gich_get_eisr();
-        lr_ind = bitmap_find_nth((bitmap_t*)&eisr, NUM_LRS, 1, 0, true);
+        lr_ind = bit64_ffs(eisr & BIT64_MASK(0, NUM_LRS));
     }
 }
 

--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -7,7 +7,7 @@
 #include <arch/csrs.h>
 #include <cpu.h>
 #include <vm.h>
-#include <bitmap.h>
+#include <bit.h>
 #include <fences.h>
 #include <hypercall.h>
 
@@ -257,7 +257,7 @@ struct sbiret sbi_ipi_handler(unsigned long fid)
     };
 
     for (size_t i = 0; i < sizeof(hart_mask) * 8; i++) {
-        if (bitmap_get((bitmap_t*)&hart_mask, i)) {
+        if (bit_get(hart_mask, i)) {
             vcpuid_t vhart_id = hart_mask_base + i;
             cpuid_t phart_id = vm_translate_to_pcpuid(cpu()->vcpu->vm, vhart_id);
             if(phart_id != INVALID_CPUID) cpu_send_msg(phart_id, &msg);
@@ -306,8 +306,8 @@ struct sbiret sbi_rfence_handler(unsigned long fid)
 
     const size_t hart_mask_width = sizeof(hart_mask) * 8;
     if ((hart_mask_base != 0) && ((hart_mask_base >= hart_mask_width) ||
-        (bitmap_find_nth((bitmap_t*)&hart_mask, hart_mask_width, 1,
-                        hart_mask_width - hart_mask_base, true) > 0))) {
+        ((hart_mask >> hart_mask_base) != 0))) 
+    {
         WARNING("sbi invalid hart_mask");
         return (struct sbiret){SBI_ERR_INVALID_PARAM};
     }

--- a/src/core/inc/vm.h
+++ b/src/core/inc/vm.h
@@ -129,19 +129,19 @@ static inline struct vcpu* vm_get_vcpu(struct vm* vm, vcpuid_t vcpuid) {
 
 static inline cpuid_t vm_translate_to_pcpuid(struct vm* vm, vcpuid_t vcpuid)
 {
-    ssize_t i = bitmap_find_nth((bitmap_t*)&vm->cpus, sizeof(vm->cpus) * 8,
-                           vcpuid + 1, 0, true);
-    if(i < 0) {
+    struct vcpu *vcpu = vm_get_vcpu(vm, vcpuid);
+
+    if(vcpu == NULL) {
         return INVALID_CPUID;
     } else {
-        return (cpuid_t)i;
+        return vcpu->phys_id;
     }
 }
 
 static inline vcpuid_t vm_translate_to_vcpuid(struct vm* vm, cpuid_t pcpuid)
 {
     if (vm->cpus & (1UL << pcpuid)) {
-        return (cpuid_t)bitmap_count((bitmap_t*)&vm->cpus, 0, pcpuid, true);
+        return (cpuid_t)bit_count(vm->cpus & BIT_MASK(0, pcpuid));
     } else {
         return INVALID_CPUID;
     }

--- a/src/lib/inc/bit.h
+++ b/src/lib/inc/bit.h
@@ -42,6 +42,31 @@
     {\
         return (~MASK(off, len) & word) | ((MASK(0, len) & val) << off);\
     }\
+    static inline ssize_t PRE ## _ffs(TYPE word)\
+    {\
+        ssize_t pos = (ssize_t)0;\
+        TYPE mask = (LIT);\
+        while (mask != 0U) {\
+            if ((mask & word) != 0U) {\
+                break;\
+            }\
+            mask <<= 1U;\
+            pos++;\
+        }\
+        return (mask != 0U) ? pos : (ssize_t)-1;\
+    }\
+    static inline ssize_t PRE ## _count(TYPE word)\
+    {\
+        size_t count = 0;\
+        TYPE mask = (LIT);\
+        while (mask != 0U) {\
+            if ((mask & word) != 0U) {\
+                count += 1;\
+            }\
+            mask <<= 1U;\
+        }\
+        return count;\
+    }
 
 BIT_OPS_GEN(bit32, uint32_t, UINT32_C(1), BIT32_MASK);
 BIT_OPS_GEN(bit64, uint64_t, UINT64_C(1), BIT64_MASK);


### PR DESCRIPTION
In order to use some of the operations defined for the `bitmap_t*` type, some functions were casting integer types pointers to `bitmap_t*`.  This is not the best practice and was causing some issues with the latest GCC versions, as pointed out in #78.

This PR fixes this issue by refactoring these operations using simple bit manipulation functions available in *bit/util/bit.h*. However, it was still needed to add the `bit_ffs` and `bit_count` functions so that all functionality needed was available.