### PR TITLE
fix(arm/spinlock): add compiler memory barrier to inline asm

### DIFF
--- a/src/arch/armv8/aarch32/inc/arch/spinlock.h
+++ b/src/arch/armv8/aarch32/inc/arch/spinlock.h
@@ -50,7 +50,7 @@ static inline void spin_lock(spinlock_t* lock)
         "b 2b\n\t"
         "3:\n\t"
         : "=&r"(ticket), "=&r"(next), "=&r"(temp)
-        : "Q"(lock->ticket), "Q"(lock->next));
+        : "Q"(lock->ticket), "Q"(lock->next) : "memory");
 }
 
 static inline void spin_unlock(spinlock_t* lock)
@@ -65,7 +65,7 @@ static inline void spin_unlock(spinlock_t* lock)
         "dsb ish\n\t"
         "sev\n\t"
         : "=&r"(temp)
-        : "Q"(lock->next));
+        : "Q"(lock->next) : "memory");
 }
 
 #endif /* __ARCH_SPINLOCK__ */

--- a/src/arch/armv8/aarch64/inc/arch/spinlock.h
+++ b/src/arch/armv8/aarch64/inc/arch/spinlock.h
@@ -49,7 +49,7 @@ static inline void spin_lock(spinlock_t* lock)
         "b 2b\n\t"
         "3:\n\t"
         : "=&r"(ticket), "=&r"(next), "=&r"(temp)
-        : "Q"(lock->ticket), "Q"(lock->next));
+        : "Q"(lock->ticket), "Q"(lock->next) : "memory");
 }
 
 static inline void spin_unlock(spinlock_t* lock)
@@ -64,7 +64,7 @@ static inline void spin_unlock(spinlock_t* lock)
         "dsb ish\n\t"
         "sev\n\t"
         : "=&r"(temp)
-        : "Q"(lock->next));
+        : "Q"(lock->next) : "memory");
 }
 
 


### PR DESCRIPTION
This is needed to avoid that compiler optimization reorder critical section instructions across the lock/unlock limits.