### PR TITLE
fix(platform): only add smmu struct when using mmu

### DIFF
--- a/src/arch/armv8/inc/arch/platform.h
+++ b/src/arch/armv8/inc/arch/platform.h
@@ -7,7 +7,9 @@
 #define __ARCH_PLATFORM_H__
 
 #include <bao.h>
+#ifdef MEM_PROT_MMU	
 #include <arch/smmuv2.h>
+#endif
 
 struct arch_platform {
     struct gic_dscrp {
@@ -20,11 +22,13 @@ struct arch_platform {
         irqid_t maintenance_id;
     } gic;
 
+#ifdef MEM_PROT_MMU	
     struct {
         paddr_t base;
         irqid_t interrupt_id;
         streamid_t global_mask;
     } smmu;
+#endif
 
     struct {
         paddr_t base_addr;

--- a/src/arch/armv8/inc/arch/vm.h
+++ b/src/arch/armv8/inc/arch/vm.h
@@ -10,7 +10,9 @@
 #include <arch/subarch/vm.h>
 #include <arch/vgic.h>
 #include <arch/psci.h>
+#ifdef MEM_PROT_MMU	
 #include <arch/smmuv2.h>
+#endif
 #include <list.h>
 
 struct arch_vm_platform {
@@ -21,6 +23,7 @@ struct arch_vm_platform {
         size_t interrupt_num;
     } gic;
 
+#ifdef MEM_PROT_MMU	
     struct {
         streamid_t global_mask;
         size_t group_num;
@@ -29,6 +32,7 @@ struct arch_vm_platform {
             streamid_t id;
         } *groups;
     } smmu;
+#endif
 };
 
 struct vm_arch {


### PR DESCRIPTION
The platform structure is the same for Arm architecture, which includes systems with MMU and/or MPU.
It is necessary to not include the SMMU struct, in systems with MPU, as the type of data used on that struct is only defined on the smmuv2 header file. 
This PR addresses the compilation error due to the smmuv2 files not being included on the MPU.