### PR TITLE
fix(riscv): fix order of clear software pending

### DIFF
--- a/src/arch/riscv/interrupts.c
+++ b/src/arch/riscv/interrupts.c
@@ -79,8 +79,8 @@ void interrupts_arch_handle()
 
     switch (_scause) {
         case SCAUSE_CODE_SSI:
-            interrupts_handle(SOFT_INT_ID);
             CSRC(sip, SIP_SSIP);
+            interrupts_handle(SOFT_INT_ID);
             break;
         case SCAUSE_CODE_STI:
             interrupts_handle(TIMR_INT_ID);


### PR DESCRIPTION
When handling software interrupts (i.e., IPIs) in risc-v we must clear the interrupt pending bit before handling the interrupt. The IPI handler (i.e., cpu msg handler) loops through the event queue until it sees no more events which solves the issue of two superimposed IPIs triggered before or while the handler runs. However, currently, if a new IPI becomes pending between the time the cpu_msg_handler ends and we clear the "software interrupt pending bit" we can loose an IPI, and a cpu message event will go unhandled until a third IPI arrives.