### PR TITLE
fix(irq): prevent interrupt reservation and improve error handling

### DIFF
--- a/src/arch/armv8/gic.c
+++ b/src/arch/armv8/gic.c
@@ -68,8 +68,10 @@ void gicd_init()
 
     /* No need to setup gicd->NSACR as all interrupts are  setup to group 1 */
 
-    interrupts_reserve(platform.arch.gic.maintenance_id,
-                       gic_maintenance_handler);
+    if(!interrupts_reserve(platform.arch.gic.maintenance_id,
+                       gic_maintenance_handler)) {
+        ERROR("Failed to reserve GIC maintenance interrupt");
+    }
 }
 
 void gic_map_mmio();

--- a/src/arch/riscv/iommu.c
+++ b/src/arch/riscv/iommu.c
@@ -334,7 +334,10 @@ void rv_iommu_init(void)
     rv_iommu.hw.reg_ptr->fqh = 0;
 
     // Allocate IRQ for FQ
-    interrupts_reserve(platform.arch.iommu.fq_irq_id, rv_iommu_fq_irq_handler);
+    if(!interrupts_reserve(platform.arch.iommu.fq_irq_id, rv_iommu_fq_irq_handler)) {
+        ERROR("Failed to reserve IOMMU FQ interrupt");
+    }
+    
     interrupts_cpu_enable(platform.arch.iommu.fq_irq_id, true);
 
     // Enable FQ (fqcsr)

--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -476,5 +476,7 @@ void sbi_init()
         }
     }
 
-    interrupts_reserve(TIMR_INT_ID, sbi_timer_irq_handler);
+    if(!interrupts_reserve(TIMR_INT_ID, sbi_timer_irq_handler)) {
+        ERROR("Failed to reserve SBI TIMR_INT_ID interrupt");
+    }
 }

--- a/src/core/inc/interrupts.h
+++ b/src/core/inc/interrupts.h
@@ -16,7 +16,7 @@ struct vm;
 typedef void (*irq_handler_t)(irqid_t int_id);
 
 void interrupts_init();
-void interrupts_reserve(irqid_t int_id, irq_handler_t handler);
+bool interrupts_reserve(irqid_t int_id, irq_handler_t handler);
 
 void interrupts_cpu_sendipi(cpuid_t target_cpu, irqid_t ipi_id);
 void interrupts_cpu_enable(irqid_t int_id, bool en);
@@ -27,7 +27,7 @@ void interrupts_clear(irqid_t int_id);
 enum irq_res { HANDLED_BY_HYP, FORWARD_TO_VM };
 enum irq_res interrupts_handle(irqid_t int_id);
 
-void interrupts_vm_assign(struct vm *vm, irqid_t id);
+bool interrupts_vm_assign(struct vm *vm, irqid_t id);
 
 /* Must be implemented by architecture */
 

--- a/src/core/interrupts.c
+++ b/src/core/interrupts.c
@@ -41,7 +41,9 @@ inline void interrupts_init()
     interrupts_arch_init();
 
     if (cpu()->id == CPU_MASTER) {
-        interrupts_reserve(IPI_CPU_MSG, cpu_msg_handler);
+        if(!interrupts_reserve(IPI_CPU_MSG, cpu_msg_handler)) {
+            ERROR("Failed to reserve IPI_CPU_MSG interrupt");
+        }
     }
 
     interrupts_cpu_enable(IPI_CPU_MSG, true);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -207,7 +207,9 @@ static void vm_init_dev(struct vm* vm, const struct vm_config* config)
         }
 
         for (size_t j = 0; j < dev->interrupt_num; j++) {
-            interrupts_vm_assign(vm, dev->interrupts[j]);
+            if(!interrupts_vm_assign(vm, dev->interrupts[j])) {
+                ERROR("Failed to assign interrupt id %d", dev->interrupts[j]);
+            }
         }
     }
 


### PR DESCRIPTION
## PR Description

This PR enhances the interrupt reservation functions to prevent race conditions during the reservation process. It comprises the following changes:

1. Added a spinlock to ensure synchronized access to the critical section, preventing race conditions. The original code lacked this synchronization, potentially leading to issues. The spinlock now ensures only one thread can access the critical section at a time, resolving the race condition (https://github.com/bao-project/bao-hypervisor/commit/196a404e58dac8ba93f08b24b06360abe5f39a8e);
2. Introduced a boolean return value to indicate the success of interrupt reservation. This provides a more detailed assessment of interrupt assignment status, aiding in error handling (https://github.com/bao-project/bao-hypervisor/commit/fc2029b8e9dc294ef4e2bbfb6946fb0eaa42ad27);
3. Improved the overall error handling for interrupt assignment (https://github.com/bao-project/bao-hypervisor/commit/5887601d39b511b9a314e21ce77bf47ebda9ee68)

Your feedback on these changes is greatly appreciated.