### PR TITLE
fix(riscv/sbi): rfence hart mask adjustment and check

### DIFF
--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -309,13 +309,13 @@ struct sbiret sbi_rfence_handler(unsigned long fid)
 
     const size_t hart_mask_width = sizeof(hart_mask) * 8;
     if ((hart_mask_base != 0) && ((hart_mask_base >= hart_mask_width) ||
-        ((hart_mask >> hart_mask_base) != 0))) 
+        ((hart_mask << hart_mask_base) == 0))) 
     {
         WARNING("sbi invalid hart_mask");
         return (struct sbiret){SBI_ERR_INVALID_PARAM};
     }
 
-    hart_mask = hart_mask >> hart_mask_base;
+    hart_mask = hart_mask << hart_mask_base;
 
     unsigned long phart_mask = vm_translate_to_pcpu_mask(
         cpu()->vcpu->vm, hart_mask, sizeof(hart_mask) * 8);


### PR DESCRIPTION
Right now, the sbi rfence implementation only supports 64 harts, so the hart mask has to be rectified for always base 0 and return error if an with hart id >= 64 is being targeted. Both this check and the hart adjusment were being incorrectly performed.

This issue was detected by @D3boker1.