### PR TITLE
Introduce CI and basic checks

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,0 +1,36 @@
+name: Bao component base workflow
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  gitlint:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: git config --global --add safe.directory $(realpath .)
+      - if: ${{ github.event_name == 'pull_request' }}
+        run: make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+      - if: ${{ github.event_name == 'push' }}
+        run: make gitlint GITLINT_BASE=${{ github.event.before }}
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: make gitlint GITLINT_BASE=HEAD
+
+  license:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - run: >
+          make license-check

--- a/.github/workflows/build-arm.yaml
+++ b/.github/workflows/build-arm.yaml
@@ -1,0 +1,30 @@
+name: Arm Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  build-arm:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    strategy:
+      matrix:
+        platform: [
+          "fvp-a",
+          "fvp-a-aarch32",
+          "fvp-r",
+          "fvp-r-aarch32"
+        ]
+        gic: [
+          "GICV2",
+          "GICV3",
+        ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: make PLATFORM=${{ matrix.platform }} GIC_VERSION=${{ matrix.gic }} CONFIG=null

--- a/.github/workflows/build-riscv.yaml
+++ b/.github/workflows/build-riscv.yaml
@@ -1,0 +1,27 @@
+name: RISC-V Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  build-riscv:
+    runs-on: ubuntu-latest
+    container: baoproject/bao:latest
+    strategy:
+      matrix:
+        platform: [
+          "qemu-riscv64-virt",
+        ]
+        irqc: [
+          "PLIC",
+          "APLIC",
+        ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: make PLATFORM=${{ matrix.platform }} IRQC=${{ matrix.irqc }} CONFIG=null

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ configs/*
 !configs/configs.mk
 !configs/linker.ld 
 !configs/example/
-
+!configs/null/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci"]
+	path = ci
+	url = git@github.com:bao-project/bao-ci.git

--- a/Makefile
+++ b/Makefile
@@ -298,3 +298,17 @@ clean:
 	@echo "Erasing directories..."
 	-rm -rf $(build_dir)
 	-rm -rf $(bin_dir)
+
+# Instantiate CI rules
+
+all_files= $(realpath \
+	$(cur_dir)/Makefile \
+	$(call list_dir_files_recursive, $(src_dir), *) \
+	$(call list_dir_files_recursive, $(scripts_dir), *) \
+	$(call list_dir_files_recursive, $(config_dir)/example, *) \
+)
+
+$(call ci, license, "Apache-2.0", $(all_files))
+
+.PHONY: ci
+ci: license-check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bao - a lightweight static partitioning hypervisor
 
+![arm build workflow](https://github.com/bao-project/bao-hypervisor/actions/workflows/build-arm.yaml/badge.svg)
+![riscv build workflow](https://github.com/bao-project/bao-hypervisor/actions/workflows/build-riscv.yaml/badge.svg)
 
 Introduction
 ------------

--- a/configs/null/config.c
+++ b/configs/null/config.c
@@ -1,0 +1,23 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+/* THIS CONFIG IS DEFINED FOR TESTING PURPOSES ONLY */
+
+#include <config.h>
+
+struct config config = {
+
+        /**
+         * This configuration has no VMs. It is used to test build the 
+         * hypervisor with an empty configuration. We have to set
+         * `vmlist_size` to 1, because the build scripts will generate
+         * a macro to define an array size from it which automatically
+         * triggers a set of `array subscript i is outside array bounds`
+         * errors and the build which we are testing in the first place
+         *  will fail.
+         */
+        .vmlist_size = 1,
+
+};


### PR DESCRIPTION
This PR introduces the bao-ci infrastructure as a git submodule and instantiates and creates Github actions for basic checks such as:

- all files have the correct license and copyright info;
- git commit message linting to enforce conventional commit convention;
- compiles without errors for a set of representative platforms for both arm and risc-v architectures.

It adds status stickers to the readme file that display the status of the build checks. You can check out how this looks [here](https://github.com/bao-project/bao-hypervisor/tree/feat/ci).