### PR TITLE
Refactor riscv sstc ext check

### DIFF
--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -43,10 +43,7 @@ void vcpu_arch_reset(struct vcpu* vcpu, vaddr_t entry)
     vcpu->regs.a1 = 0; // according to sbi it should be the dtb load address
 
     if (CPU_HAS_EXTENSION(CPU_EXT_SSTC)) {
-        CSRW(CSR_STIMECMP, -1);
-        CSRS(CSR_HENVCFG, HENVCFG_STCE);
-    } else {
-        CSRC(CSR_HENVCFG, HENVCFG_STCE);
+        CSRW(CSR_VSTIMECMP, -1);
     }
     CSRW(CSR_HCOUNTEREN, HCOUNTEREN_TM);
     CSRW(CSR_HTIMEDELTA, 0);


### PR DESCRIPTION
This PR centralizes the enabling of the RISCV sstc extension in the vmm architectural initialization function. It also adds the sanity checking that the extension is effectively present if the hypervisor was configured to used it (via a platform-defined macro).

Depends on #106 