### PR TITLE
feat(cpu_standby): include support to standby the CPU

### DIFF
--- a/src/arch/armv8/armv8-a/cpu.c
+++ b/src/arch/armv8/armv8-a/cpu.c
@@ -48,3 +48,11 @@ void cpu_arch_profile_idle()
      * architectural
      */
 }
+
+void cpu_arch_profile_standby()
+{
+    /**
+     * Wait for an interrupt
+     */
+    asm volatile("wfi");
+}

--- a/src/arch/armv8/armv8-r/cpu.c
+++ b/src/arch/armv8/armv8-r/cpu.c
@@ -10,5 +10,16 @@ void cpu_arch_profile_init(cpuid_t cpuid, paddr_t load_addr) { }
 
 void cpu_arch_profile_idle()
 {
+    /**
+     * Wait for an interrupt
+     */
+    asm volatile("wfi");
+}
+
+void cpu_arch_profile_standby()
+{
+    /**
+     * Wait for an interrupt
+     */
     asm volatile("wfi");
 }

--- a/src/arch/armv8/cpu.c
+++ b/src/arch/armv8/cpu.c
@@ -36,3 +36,18 @@ void cpu_arch_idle()
 
     ERROR("returned from idle wake up");
 }
+
+void cpu_arch_standby()
+{
+    cpu_arch_profile_standby();
+
+    /*
+     * In case the profile implementation does not jump to a predefined wake-up
+     * point and just returns from the profile, manually rewind stack and jump
+     * to idle wake up. Therefore, we should not return after this point.
+     */
+    asm volatile("mov sp, %0\n\r"
+                 "b cpu_idle_wakeup\n\r" ::"r"(&cpu()->stack[STACK_SIZE]));
+
+    ERROR("returned from idle wake up");
+}

--- a/src/arch/armv8/inc/arch/cpu.h
+++ b/src/arch/armv8/inc/arch/cpu.h
@@ -19,6 +19,7 @@ struct cpu_arch {
 unsigned long cpu_id_to_mpidr(cpuid_t id);
 void cpu_arch_profile_init(cpuid_t cpuid, paddr_t load_addr);
 void cpu_arch_profile_idle();
+void cpu_arch_profile_standby();
 
 extern cpuid_t CPU_MASTER;
 

--- a/src/arch/armv8/vm.c
+++ b/src/arch/armv8/vm.c
@@ -91,5 +91,5 @@ void vcpu_arch_run(struct vcpu* vcpu)
         vcpu_arch_entry();
     } else {
         cpu_standby();
-    }   
+    }
 }

--- a/src/arch/armv8/vm.c
+++ b/src/arch/armv8/vm.c
@@ -90,6 +90,6 @@ void vcpu_arch_run(struct vcpu* vcpu)
     if (vcpu_psci_state_on(vcpu)) {
         vcpu_arch_entry();
     } else {
-        cpu_idle();
-    }
+        cpu_standby();
+    }   
 }

--- a/src/arch/riscv/cpu.c
+++ b/src/arch/riscv/cpu.c
@@ -34,3 +34,8 @@ void cpu_arch_idle()
                  "j cpu_idle_wakeup\n\r" ::"r"(&cpu()->stack[STACK_SIZE]));
     ERROR("returned from idle wake up");
 }
+
+void cpu_arch_standby()
+{
+    cpu_arch_idle();
+}

--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -92,6 +92,6 @@ void vcpu_arch_run(struct vcpu* vcpu)
     if (vcpu->arch.sbi_ctx.state == STARTED) {
         vcpu_arch_entry();
     } else {
-        cpu_idle();
-    }
+        cpu_standby();
+    }    
 }

--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -93,5 +93,5 @@ void vcpu_arch_run(struct vcpu* vcpu)
         vcpu_arch_entry();
     } else {
         cpu_standby();
-    }    
+    }
 }

--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -99,6 +99,18 @@ void cpu_idle()
     ERROR("Spurious idle wake up");
 }
 
+void cpu_standby()
+{
+    cpu_arch_standby();
+
+    /**
+     * Should not return here.
+     * cpu should "wake up" from idle in cpu_idle_wakeup
+     * with a rewinded stack.
+     */
+    ERROR("Spurious idle wake up");
+}
+
 void cpu_idle_wakeup()
 {
     if (interrupts_check(IPI_CPU_MSG)) {

--- a/src/core/inc/cpu.h
+++ b/src/core/inc/cpu.h
@@ -68,10 +68,12 @@ bool cpu_get_msg(struct cpu_msg* msg);
 void cpu_msg_handler();
 void cpu_msg_set_handler(cpuid_t id, cpu_msg_handler_t handler);
 void cpu_idle();
+void cpu_standby();
 void cpu_idle_wakeup();
 
 void cpu_arch_init(cpuid_t cpu_id, paddr_t load_addr);
 void cpu_arch_idle();
+void cpu_arch_standby();
 
 extern struct cpuif cpu_interfaces[];
 static inline struct cpuif* cpu_if(cpuid_t cpu_id)


### PR DESCRIPTION
# PR Summary

This pull request introduces the functionality to transition the CPU into a standby state rather than leaving it idle. This becomes especially pertinent when there's a necessity to set the CPU to an idle state without entirely suspending its operation.

For instance, the current implementation using the ``cpu_idle`` function prohibits waking up the CPU via a timer interrupt. To address this limitation, this PR encompasses three significant commits:

1. Commit e408c9cae16076b9c949bd532d203872749bd62c: Implements the necessary changes in the core to support CPU standby functionality.
2. Commit 811d12c0a26af361afa93d0f03780846ff272aeb: Enables the armv8 architecture to seamlessly support the CPU standby mode.
3. Commit c5423e1ff337b22dfd8b92e2df24ec1e0ce52336:  Facilitates the RISC-V architecture to effectively support CPU standby operations.

Your feedback on these changes would be appreciated. Please provide your thoughts. Thank you!