### PR TITLE
fix(core/vmm): fixe use of fences on VMM install

### DIFF
--- a/src/core/mmu/vmm.c
+++ b/src/core/mmu/vmm.c
@@ -5,6 +5,7 @@
 
 #include <vmm.h>
 #include <io.h>
+#include <fences.h>
 
 void vmm_io_init()
 {
@@ -24,4 +25,7 @@ void vmm_vm_install(struct vm_install_info* install_info)
 {
     pte_t* pte = pt_get_pte(&cpu()->as.pt, 0, (vaddr_t)install_info->base);
     *pte = install_info->vm_section_pte;
+    // We don't invalidate the TLB as we know there was no previous mapping or accesses to the
+    // addresses in the VM section. Just make sure the write commited before leaving.
+    fence_ord_write();
 }

--- a/src/core/vmm.c
+++ b/src/core/vmm.c
@@ -116,8 +116,8 @@ static struct vm_allocation* vmm_alloc_install_vm(vmid_t vm_id, bool master)
         vm_assign[vm_id].install_info_ready = true;
     } else {
         while (!vm_assign[vm_id].install_info_ready) { }
+        fence_ord_read();
         vmm_vm_install(&vm_assign[vm_id].vm_install_info);
-        fence_sync_write();
     }
 
     return vm_alloc;


### PR DESCRIPTION
First a fence was required to enforce the dependency on `install_info_ready` being set calling vmm_vm_install as there is no real data dependency.

Second, we move the write fence which ensures the write to the page table is visible to within the install function. It is it responsibility to ensure it returns with its effects visible.