### PR TITLE
Add support for 32-bit RISC-V

### DIFF
--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -1,7 +1,21 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
+ARCH_SUB?=riscv64
+
+ifeq ($(ARCH_SUB), riscv64)
 CROSS_COMPILE ?= riscv64-unknown-elf-
+riscv_march:=rv64imac_zicsr
+riscv_mabi:=lp64
+ld_emulation:=elf64lriscv
+else ifeq ($(ARCH_SUB), riscv32)
+CROSS_COMPILE ?= riscv32-unknown-elf-
+riscv_march:=rv32imac_zicsr
+riscv_mabi:=ilp32
+ld_emulation:=elf32lriscv
+else
+$(error RISC-V $(ARCH_SUB) not supported!)
+endif
 
 # Interrupt controller source files
 ifeq ($(IRQC), PLIC)
@@ -17,10 +31,16 @@ endif
 irqc_arch_dir=$(cpu_arch_dir)/irqc/$(IRQC_DIR)
 src_dirs+=$(irqc_arch_dir)
 
+ifeq ($(ARCH_SUB), riscv64)
+arch-cppflags+=-DRV_XLEN=64
+else ifeq ($(ARCH_SUB), riscv32)
+arch-cppflags+=-DRV_XLEN=32
+endif
 arch-cppflags+=-DIRQC=$(IRQC)
-arch-cflags = -mcmodel=medany -march=rv64g -mstrict-align
+arch-cflags = -mcmodel=medany -march=$(riscv_march) -mstrict-align \
+	-mabi=$(riscv_mabi)
 arch-asflags =
-arch-ldflags = 
+arch-ldflags = -m $(ld_emulation)
 
 arch_mem_prot:=mmu
 PAGE_SIZE:=0x1000

--- a/src/arch/riscv/boot.S
+++ b/src/arch/riscv/boot.S
@@ -19,9 +19,10 @@
  */
 .macro PTE_INDEX_ASM	index, addr, level
 	srl \index, \addr, PTE_INDEX_SHIFT(\level) 
-    li  s0, ((PAGE_SIZE/8)-1)
+    li  s0, ((PAGE_SIZE/REGLEN)-1)
 	and \index, \index, s0
-	sll \index, \index, 3
+    li  s0, REGLEN
+	mul \index, \index, s0
 .endm
 
 /**
@@ -118,7 +119,7 @@ _reset_handler:
  */
     la      t0, CPU_MASTER
     li      t1, CPU_MASTER_FIXED
-    sd      t1, 0(t0)
+    STORE   t1, 0(t0)
 #else
 /**
  * The first hart to grab the lock is CPU_MASTER.
@@ -135,7 +136,7 @@ _boot_lock:
     sc.w    t2, t1, (t0)   
     bnez    t2, 1b 
     la      t0, CPU_MASTER
-    sd      a0, 0(t0)
+    STORE      a0, 0(t0)
 2:
 #endif
 
@@ -151,6 +152,7 @@ _boot_lock:
     add     a4, a4, s6
 	call	clear		 
 
+
     la          t0, root_l1_pt
     add         t0, t0, s6
     la          t1, root_l2_pt
@@ -164,23 +166,23 @@ _boot_lock:
     la          t0, root_l2_pt
     add         t0, t0, s6
     LD_SYM      t1, _image_start_sym
-    PTE_PTR     t1, t0, 2, t1
+    PTE_PTR     t1, t0, (PT_LVLS - 1), t1
     LD_SYM      t2, _image_load_end_sym
-    PTE_PTR     t2, t0, 2, t2
+    PTE_PTR     t2, t0, (PT_LVLS - 1), t2
 
     la          t0, _image_start
     PTE_FILL    t0, t0, PTE_HYP_FLAGS | PTE_PAGE
 1:
     bge     t1, t2, 2f
     STORE   t0, 0(t1)
-    add     t1, t1, 8
-    add     t0, t0, 0x400
+    add     t1, t1, REGLEN
+    add     t0, t0, (PAGE_SIZE >> 2)
     j       1b
 2:
     la          t0, root_l2_pt
     add         t0, t0, s6
     LD_SYM      t2, _image_end_sym
-    PTE_PTR     t2, t0, 2, t2
+    PTE_PTR     t2, t0, (PT_LVLS - 1), t2
     bge         t1, t2, 3f
     la          t0, _image_noload_start
     PTE_FILL    t0, t0, PTE_HYP_FLAGS | PTE_PAGE
@@ -252,8 +254,8 @@ map_cpu:
 1:
     blez    t3, setup_cpu
     STORE   t2, 0(t1)
-    add     t1, t1, 8
-    add     t2, t2, 0x400
+    add     t1, t1, REGLEN
+    add     t2, t2, (PAGE_SIZE >> 2)
     sub     t3, t3, t4
     j       1b
     

--- a/src/arch/riscv/boot.S
+++ b/src/arch/riscv/boot.S
@@ -10,8 +10,13 @@
 #include <platform_defs.h>
 
 #define PT_SIZE PAGE_SIZE
+#if RV64
 #define PT_LVLS 3
 #define PTE_INDEX_SHIFT(LEVEL) ((9 * (PT_LVLS - 1 - (LEVEL))) + 12)
+#else
+#define PT_LVLS 2
+#define PTE_INDEX_SHIFT(LEVEL) ((10 * (PT_LVLS - 1 - (LEVEL))) + 12)
+#endif 
 
 /**
  * Calculates the index or offset of a page table entry for given virtual address(addr) at a given
@@ -57,6 +62,7 @@ _dmem_beg_sym: .8byte _dmem_beg
 _enter_vas_sym: .8byte _enter_vas
 _bss_start_sym: .8byte _bss_start
 _bss_end_sym: .8byte _bss_end
+_extra_allocated_phys_mem_sym: .8byte extra_allocated_phys_mem
 
 .data 
 .align 3
@@ -91,7 +97,7 @@ _reset_handler:
 
     mv      a2, a1
     la      a1, _image_start
-    la      s6, extra_allocated_phys_mem
+    LD_SYM  s6, _extra_allocated_phys_mem_sym
 
     /**
      * Setup stvec early. In case of we cause an exception in this boot code we end up at a known
@@ -140,7 +146,7 @@ _boot_lock:
 2:
 #endif
 
-    /* Setup bootstrap page tables. Assuming sv39 support. */ 
+    /* Setup bootstrap page tables. Assuming sv39 or sv32 support. */ 
 
  	/* Skip initialy global page tables setup if not hart */
     LD_SYM  t0, CPU_MASTER
@@ -155,16 +161,16 @@ _boot_lock:
 
     la          t0, root_l1_pt
     add         t0, t0, s6
+#if RV64
     la          t1, root_l2_pt
     add         t1, t1, s6
     PTE_FILL    t1, t1, PTE_TABLE
     li          t2, BAO_VAS_BASE
     PTE_PTR     t2, t0, 1, t2
     STORE       t1, 0(t2)
-
-
     la          t0, root_l2_pt
     add         t0, t0, s6
+#endif
     LD_SYM      t1, _image_start_sym
     PTE_PTR     t1, t0, (PT_LVLS - 1), t1
     LD_SYM      t2, _image_load_end_sym
@@ -179,7 +185,11 @@ _boot_lock:
     add     t0, t0, (PAGE_SIZE >> 2)
     j       1b
 2:
+#if RV64
     la          t0, root_l2_pt
+#else
+    la          t0, root_l1_pt
+#endif
     add         t0, t0, s6
     LD_SYM      t2, _image_end_sym
     PTE_PTR     t2, t0, (PT_LVLS - 1), t2
@@ -215,13 +225,6 @@ map_cpu:
     li      t2, CPU_SIZE
     add     t1, t0, t2
 
-    /* Flat mapping to switch to VAS. */
-    PTE_PTR     t2, t1, 0, a1
-    li          t3, ~((1 << 30) -1)
-    and         t3, a1, t3          //align a1 to 1GB (levle 0 superpage)  
-    PTE_FILL    t3, t3, PTE_HYP_FLAGS | PTE_PAGE | PTE_SUPERPAGE
-    STORE       t3, 0(t2)
-
     /* Add root l1 page table pointer to root page table */
     la          t2, root_l1_pt
     add         t2, t2, s6
@@ -238,13 +241,14 @@ map_cpu:
     PTE_PTR     t3, t1, 0, t3
     STORE       t2, 0(t3)
 
+#if RV64
     add         t1, t1, t4
     add         t2, t1, t4
     PTE_FILL    t2, t2, PTE_TABLE
     li          t3, BAO_CPU_BASE
     PTE_PTR     t3, t1, 1, t3
     STORE       t2, 0(t3)
-
+#endif
 
     add         t1, t1, t4
     li          t2, BAO_CPU_BASE
@@ -270,8 +274,10 @@ setup_cpu:
     li      t2, SATP_MODE_DFLT
     or      t0, t0, t2
 
-    la      t2, _enter_vas_sym
-    LOAD    t2, 0(t2)
+    LD_SYM      t2, _enter_vas_sym
+    and     t3, t2, ~STVEC_MODE_MSK
+    or      t3, t3, STVEC_MODE_DIRECT
+    csrw    stvec, t3
 
     sfence.vma
     csrw   satp, t0

--- a/src/arch/riscv/inc/arch/bao.h
+++ b/src/arch/riscv/inc/arch/bao.h
@@ -6,16 +6,8 @@
 #ifndef __ARCH_BAO_H__
 #define __ARCH_BAO_H__
 
-#ifdef __riscv__
-#define RV64 (__riscv_xlen == 64)
-#define RV32 (__riscv_xlen == 32)
-#else
-#define RV64 1
-#endif
-
-#if (!(RV64))
-#error "Unsupported __riscv_xlen #__riscv_xlen."
-#endif
+#define RV64 (RV_XLEN == 64)
+#define RV32 (RV_XLEN == 32)
 
 #if (RV64)
 #define LOAD   ld
@@ -28,15 +20,20 @@
 #endif
 
 #if (RV64)
+// This layout assumes Sv39 is available as mandated by the RVA23S64 profile
 #define BAO_VAS_BASE (0xffffffc000000000)
 #define BAO_CPU_BASE (0xffffffc040000000)
 #define BAO_VM_BASE  (0xffffffe000000000)
 #define BAO_VAS_TOP  (0xfffffff000000000)
-#elif (RV32)
+#else
+// Because sv32 only lowest level only supports 4MiB pages, this should be enough for each section
+// otherwise we need allow for N shared PTEs for each section. For now, it seems to suffice. We also
+// are assuming, for now that all available physical memory resides in 0x0 - 0xefffffff of virtual
+// memory. Otherwise we need to implement a "highmem"-like mechanism.
 #define BAO_VAS_BASE (0xc0000000)
-#define BAO_CPU_BASE (0x00000000)
-#define BAO_VM_BASE  (0x00000000)
-#define BAO_VAS_TOP  (0xffffffff)
+#define BAO_CPU_BASE (0xcf400000)
+#define BAO_VM_BASE  (0xcf800000)
+#define BAO_VAS_TOP  (0xcfc00000)
 #endif
 
 #define PAGE_SIZE        (0x1000)

--- a/src/arch/riscv/inc/arch/csrs.h
+++ b/src/arch/riscv/inc/arch/csrs.h
@@ -65,137 +65,142 @@
 #define HGATP_VMID_LEN (7)
 #endif
 
-#define SATP_MODE_BARE              (0ULL << SATP_MODE_OFF)
-#define SATP_MODE_32                (1ULL << SATP_MODE_OFF)
-#define SATP_MODE_39                (8ULL << SATP_MODE_OFF)
-#define SATP_MODE_48                (9ULL << SATP_MODE_OFF)
-#define SATP_ASID_MSK               BIT_MASK(SATP_ASID_OFF, SATP_ASID_LEN)
+#define SATP_MODE_BARE     (0ULL << SATP_MODE_OFF)
+#define SATP_MODE_32       (1ULL << SATP_MODE_OFF)
+#define SATP_MODE_39       (8ULL << SATP_MODE_OFF)
+#define SATP_MODE_48       (9ULL << SATP_MODE_OFF)
+#define SATP_ASID_MSK      BIT_MASK(SATP_ASID_OFF, SATP_ASID_LEN)
 
-#define HGATP_MODE_OFF              SATP_MODE_OFF
-#define HGATP_MODE_DFLT             SATP_MODE_DFLT
-#define HGATP_VMID_MSK              BIT_MASK(HGATP_VMID_OFF, HGATP_VMID_LEN)
+#define HGATP_MODE_OFF     SATP_MODE_OFF
+#define HGATP_MODE_DFLT    SATP_MODE_DFLT
+#define HGATP_VMID_MSK     BIT_MASK(HGATP_VMID_OFF, HGATP_VMID_LEN)
 
-#define SSTATUS_UIE_BIT             (1ULL << 0)
-#define SSTATUS_SIE_BIT             (1ULL << 1)
-#define SSTATUS_UPIE_BIT            (1ULL << 4)
-#define SSTATUS_SPIE_BIT            (1ULL << 5)
-#define SSTATUS_SPP_BIT             (1ULL << 8)
-#define SSTATUS_FS_OFF              (13)
-#define SSTATUS_FS_LEN              (2)
-#define SSTATUS_FS_MSK              BIT_MASK(SSTATUS_FS_OFF, SSTATUS_FS_LEN)
-#define SSTATUS_FS_AOFF             (0)
-#define SSTATUS_FS_INITIAL          (1ULL << SSTATUS_FS_OFF)
-#define SSTATUS_FS_CLEAN            (2ULL << SSTATUS_FS_OFF)
-#define SSTATUS_FS_DIRTY            (3ULL << SSTATUS_FS_OFF)
-#define SSTATUS_XS_OFF              (15)
-#define SSTATUS_XS_LEN              (2)
-#define SSTATUS_XS_MSK              BIT_MASK(SSTATUS_XS_OFF, SSTATUS_XS_LEN)
-#define SSTATUS_XS_AOFF             (0)
-#define SSTATUS_XS_INITIAL          (1ULL << SSTATUS_XS_OFF)
-#define SSTATUS_XS_CLEAN            (2ULL << SSTATUS_XS_OFF)
-#define SSTATUS_XS_DIRTY            (3ULL << SSTATUS_XS_OFF)
-#define SSTATUS_SUM                 (1ULL << 18)
-#define SSTATUS_MXR                 (1ULL << 19)
-#define SSTATUS_SD                  (1ULL << 63)
+#define SSTATUS_UIE_BIT    (1ULL << 0)
+#define SSTATUS_SIE_BIT    (1ULL << 1)
+#define SSTATUS_UPIE_BIT   (1ULL << 4)
+#define SSTATUS_SPIE_BIT   (1ULL << 5)
+#define SSTATUS_SPP_BIT    (1ULL << 8)
+#define SSTATUS_FS_OFF     (13)
+#define SSTATUS_FS_LEN     (2)
+#define SSTATUS_FS_MSK     BIT_MASK(SSTATUS_FS_OFF, SSTATUS_FS_LEN)
+#define SSTATUS_FS_AOFF    (0)
+#define SSTATUS_FS_INITIAL (1ULL << SSTATUS_FS_OFF)
+#define SSTATUS_FS_CLEAN   (2ULL << SSTATUS_FS_OFF)
+#define SSTATUS_FS_DIRTY   (3ULL << SSTATUS_FS_OFF)
+#define SSTATUS_XS_OFF     (15)
+#define SSTATUS_XS_LEN     (2)
+#define SSTATUS_XS_MSK     BIT_MASK(SSTATUS_XS_OFF, SSTATUS_XS_LEN)
+#define SSTATUS_XS_AOFF    (0)
+#define SSTATUS_XS_INITIAL (1ULL << SSTATUS_XS_OFF)
+#define SSTATUS_XS_CLEAN   (2ULL << SSTATUS_XS_OFF)
+#define SSTATUS_XS_DIRTY   (3ULL << SSTATUS_XS_OFF)
+#define SSTATUS_SUM        (1ULL << 18)
+#define SSTATUS_MXR        (1ULL << 19)
+#define SSTATUS_SD         (1ULL << (REGLEN - 1))
 
-#define SIE_USIE                    (1ULL << 0)
-#define SIE_SSIE                    (1ULL << 1)
-#define SIE_UTIE                    (1ULL << 4)
-#define SIE_STIE                    (1ULL << 5)
-#define SIE_UEIE                    (1ULL << 8)
-#define SIE_SEIE                    (1ULL << 9)
+#define SIE_USIE           (1ULL << 0)
+#define SIE_SSIE           (1ULL << 1)
+#define SIE_UTIE           (1ULL << 4)
+#define SIE_STIE           (1ULL << 5)
+#define SIE_UEIE           (1ULL << 8)
+#define SIE_SEIE           (1ULL << 9)
 
-#define SIP_USIP                    SIE_USIE
-#define SIP_SSIP                    SIE_SSIE
-#define SIP_UTIP                    SIE_UTIE
-#define SIP_STIP                    SIE_STIE
-#define SIP_UEIP                    SIE_UEIE
-#define SIP_SEIP                    SIE_SEIE
+#define SIP_USIP           SIE_USIE
+#define SIP_SSIP           SIE_SSIE
+#define SIP_UTIP           SIE_UTIE
+#define SIP_STIP           SIE_STIE
+#define SIP_UEIP           SIE_UEIE
+#define SIP_SEIP           SIE_SEIE
 
-#define HIE_VSSIE                   (1ULL << 2)
-#define HIE_VSTIE                   (1ULL << 6)
-#define HIE_VSEIE                   (1ULL << 10)
-#define HIE_SGEIE                   (1ULL << 12)
+#define HIE_VSSIE          (1ULL << 2)
+#define HIE_VSTIE          (1ULL << 6)
+#define HIE_VSEIE          (1ULL << 10)
+#define HIE_SGEIE          (1ULL << 12)
 
-#define HIP_VSSIP                   HIE_VSSIE
-#define HIP_VSTIP                   HIE_VSTIE
-#define HIP_VSEIP                   HIE_VSEIE
-#define HIP_SGEIP                   HIE_SGEIE
+#define HIP_VSSIP          HIE_VSSIE
+#define HIP_VSTIP          HIE_VSTIE
+#define HIP_VSEIP          HIE_VSEIE
+#define HIP_SGEIP          HIE_SGEIE
 
-#define SCAUSE_INT_BIT              (1ULL << ((REGLEN * 8) - 1))
-#define SCAUSE_CODE_MSK             (SCAUSE_INT_BIT - 1)
-#define SCAUSE_CODE_USI             (0 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_SSI             (1 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_VSSI            (2 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_UTI             (4 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_STI             (5 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_VSTI            (6 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_UEI             (8 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_SEI             (9 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_VSEI            (10 | SCAUSE_INT_BIT)
-#define SCAUSE_CODE_IAM             (0)
-#define SCAUSE_CODE_IAF             (1)
-#define SCAUSE_CODE_ILI             (2)
-#define SCAUSE_CODE_BKP             (3)
-#define SCAUSE_CODE_LAM             (4)
-#define SCAUSE_CODE_LAF             (5)
-#define SCAUSE_CODE_SAM             (6)
-#define SCAUSE_CODE_SAF             (7)
-#define SCAUSE_CODE_ECU             (8)
-#define SCAUSE_CODE_ECS             (9)
-#define SCAUSE_CODE_ECV             (10)
-#define SCAUSE_CODE_IPF             (12)
-#define SCAUSE_CODE_LPF             (13)
-#define SCAUSE_CODE_SPF             (15)
-#define SCAUSE_CODE_IGPF            (20)
-#define SCAUSE_CODE_LGPF            (21)
-#define SCAUSE_CODE_VRTI            (22)
-#define SCAUSE_CODE_SGPF            (23)
+#define SCAUSE_INT_BIT     (1ULL << ((REGLEN * 8) - 1))
+#define SCAUSE_CODE_MSK    (SCAUSE_INT_BIT - 1)
+#define SCAUSE_CODE_USI    (0 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_SSI    (1 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_VSSI   (2 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_UTI    (4 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_STI    (5 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_VSTI   (6 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_UEI    (8 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_SEI    (9 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_VSEI   (10 | SCAUSE_INT_BIT)
+#define SCAUSE_CODE_IAM    (0)
+#define SCAUSE_CODE_IAF    (1)
+#define SCAUSE_CODE_ILI    (2)
+#define SCAUSE_CODE_BKP    (3)
+#define SCAUSE_CODE_LAM    (4)
+#define SCAUSE_CODE_LAF    (5)
+#define SCAUSE_CODE_SAM    (6)
+#define SCAUSE_CODE_SAF    (7)
+#define SCAUSE_CODE_ECU    (8)
+#define SCAUSE_CODE_ECS    (9)
+#define SCAUSE_CODE_ECV    (10)
+#define SCAUSE_CODE_IPF    (12)
+#define SCAUSE_CODE_LPF    (13)
+#define SCAUSE_CODE_SPF    (15)
+#define SCAUSE_CODE_IGPF   (20)
+#define SCAUSE_CODE_LGPF   (21)
+#define SCAUSE_CODE_VRTI   (22)
+#define SCAUSE_CODE_SGPF   (23)
 
-#define HIDELEG_USI                 SIP_USIP
-#define HIDELEG_SSI                 SIP_SSIP
-#define HIDELEG_UTI                 SIP_UTIP
-#define HIDELEG_STI                 SIP_STIP
-#define HIDELEG_UEI                 SIP_UEIP
-#define HIDELEG_SEI                 SIP_SEIP
-#define HIDELEG_VSSI                HIP_VSSIP
-#define HIDELEG_VSTI                HIP_VSTIP
-#define HIDELEG_VSEI                HIP_VSEIP
-#define HIDELEG_SGEI                HIP_SGEIP
+#define HIDELEG_USI        SIP_USIP
+#define HIDELEG_SSI        SIP_SSIP
+#define HIDELEG_UTI        SIP_UTIP
+#define HIDELEG_STI        SIP_STIP
+#define HIDELEG_UEI        SIP_UEIP
+#define HIDELEG_SEI        SIP_SEIP
+#define HIDELEG_VSSI       HIP_VSSIP
+#define HIDELEG_VSTI       HIP_VSTIP
+#define HIDELEG_VSEI       HIP_VSEIP
+#define HIDELEG_SGEI       HIP_SGEIP
 
-#define HEDELEG_IAM                 (1ULL << 0)
-#define HEDELEG_IAF                 (1ULL << 1)
-#define HEDELEG_ILI                 (1ULL << 2)
-#define HEDELEG_BKP                 (1ULL << 3)
-#define HEDELEG_LAM                 (1ULL << 4)
-#define HEDELEG_LAF                 (1ULL << 5)
-#define HEDELEG_SAM                 (1ULL << 6)
-#define HEDELEG_SAF                 (1ULL << 7)
-#define HEDELEG_ECU                 (1ULL << 8)
-#define HEDELEG_ECS                 (1ULL << 9)
-#define HEDELEG_ECV                 (1ULL << 10)
-#define HEDELEG_IPF                 (1ULL << 12)
-#define HEDELEG_LPF                 (1ULL << 13)
-#define HEDELEG_SPF                 (1ULL << 15)
+#define HEDELEG_IAM        (1ULL << 0)
+#define HEDELEG_IAF        (1ULL << 1)
+#define HEDELEG_ILI        (1ULL << 2)
+#define HEDELEG_BKP        (1ULL << 3)
+#define HEDELEG_LAM        (1ULL << 4)
+#define HEDELEG_LAF        (1ULL << 5)
+#define HEDELEG_SAM        (1ULL << 6)
+#define HEDELEG_SAF        (1ULL << 7)
+#define HEDELEG_ECU        (1ULL << 8)
+#define HEDELEG_ECS        (1ULL << 9)
+#define HEDELEG_ECV        (1ULL << 10)
+#define HEDELEG_IPF        (1ULL << 12)
+#define HEDELEG_LPF        (1ULL << 13)
+#define HEDELEG_SPF        (1ULL << 15)
 
-#define MISA_H                      (1ULL << 7)
+#define MISA_H             (1ULL << 7)
 
-#define HSTATUS_VSBE                (1ULL << 5)
-#define HSTATUS_GVA                 (1ULL << 6)
-#define HSTATUS_SPV                 (1ULL << 7)
-#define HSTATUS_SPVP                (1ULL << 8)
-#define HSTATUS_HU                  (1ULL << 9)
-#define HSTATUS_VGEIN_OFF           (12)
-#define HSTATUS_VGEIN_LEN           (12)
-#define HSTATUS_VGEIN_MSK           (BIT_MASK(HSTATUS_VGEIN_OFF, HSTATUS_VGEIN_LEN))
-#define HSTATUS_VTVM                (1ULL << 20)
-#define HSTATUS_VTW                 (1ULL << 21)
-#define HSTATUS_VTSR                (1ULL << 22)
-#define HSTATUS_VSXL_OFF            (32)
-#define HSTATUS_VSXL_LEN            (2)
-#define HSTATUS_VSXL_MSK            (BIT_MASK(HSTATUS_VSXL_OFF, HSTATUS_VSXL_LEN))
-#define HSTATUS_VSXL_32             (1ULL << HSTATUS_VSXL_OFF)
-#define HSTATUS_VSXL_64             (2ULL << HSTATUS_VSXL_OFF)
+#define HSTATUS_VSBE       (1ULL << 5)
+#define HSTATUS_GVA        (1ULL << 6)
+#define HSTATUS_SPV        (1ULL << 7)
+#define HSTATUS_SPVP       (1ULL << 8)
+#define HSTATUS_HU         (1ULL << 9)
+#define HSTATUS_VGEIN_OFF  (12)
+#define HSTATUS_VGEIN_LEN  (12)
+#define HSTATUS_VGEIN_MSK  (BIT_MASK(HSTATUS_VGEIN_OFF, HSTATUS_VGEIN_LEN))
+#define HSTATUS_VTVM       (1ULL << 20)
+#define HSTATUS_VTW        (1ULL << 21)
+#define HSTATUS_VTSR       (1ULL << 22)
+#define HSTATUS_VSXL_OFF   (32)
+#if RV64
+#define HSTATUS_VSXL_LEN (2)
+#define HSTATUS_VSXL_MSK (BIT_MASK(HSTATUS_VSXL_OFF, HSTATUS_VSXL_LEN))
+#define HSTATUS_VSXL_32  (1UL << HSTATUS_VSXL_OFF)
+#define HSTATUS_VSXL_64  (2UL << HSTATUS_VSXL_OFF)
+#else
+#define HSTATUS_VSXL_32 0
+#define HSTATUS_VSXL_64 0
+#endif
 
 #define HENVCFG_FIOM                (1ULL << 0)
 #define HENVCFG_CBIE_OFF            (4)
@@ -239,6 +244,27 @@
 
 #define CSRS_GEN_ACCESSORS(csr) CSRS_GEN_ACCESSORS_NAMED(csr, csr)
 
+#define CSRS_GEN_ACCESSORS_MERGED(csr_name, csrl, csrh)                                 \
+    static inline unsigned long long csrs_##csr_name##_read(void)                       \
+    {                                                                                   \
+        return ((unsigned long long)csrs_##csrh##_read() << 32) | csrs_##csrl##_read(); \
+    }                                                                                   \
+    static inline void csrs_##csr_name##_write(unsigned long long csr_value)            \
+    {                                                                                   \
+        csrs_##csrl##_write((unsigned long)csr_value);                                  \
+        csrs_##csrh##_write((unsigned long)(csr_value >> 32));                          \
+    }                                                                                   \
+    static inline void csrs_##csr_name##_set(unsigned long long csr_value)              \
+    {                                                                                   \
+        csrs_##csrl##_set((unsigned long)csr_value);                                    \
+        csrs_##csrh##_set((unsigned long)(csr_value >> 32));                            \
+    }                                                                                   \
+    static inline void csrs_##csr_name##_clear(unsigned long long csr_value)            \
+    {                                                                                   \
+        csrs_##csrl##_clear((unsigned long)csr_value);                                  \
+        csrs_##csrh##_clear((unsigned long)(csr_value >> 32));                          \
+    }
+
 CSRS_GEN_ACCESSORS(sstatus)
 CSRS_GEN_ACCESSORS(sscratch)
 CSRS_GEN_ACCESSORS(scause)
@@ -255,9 +281,6 @@ CSRS_GEN_ACCESSORS_NAMED(htval, CSR_HTVAL)
 CSRS_GEN_ACCESSORS_NAMED(hideleg, CSR_HIDELEG)
 CSRS_GEN_ACCESSORS_NAMED(hedeleg, CSR_HEDELEG)
 CSRS_GEN_ACCESSORS_NAMED(hcounteren, CSR_HCOUNTEREN)
-CSRS_GEN_ACCESSORS_NAMED(stimecmp, CSR_STIMECMP)
-CSRS_GEN_ACCESSORS_NAMED(vstimecmp, CSR_VSTIMECMP)
-CSRS_GEN_ACCESSORS_NAMED(henvcfg, CSR_HENVCFG)
 CSRS_GEN_ACCESSORS_NAMED(vsstatus, CSR_VSSTATUS)
 CSRS_GEN_ACCESSORS_NAMED(vstvec, CSR_VSTVEC)
 CSRS_GEN_ACCESSORS_NAMED(vsscratch, CSR_VSSCRATCH)
@@ -267,8 +290,30 @@ CSRS_GEN_ACCESSORS_NAMED(vstval, CSR_VSTVAL)
 CSRS_GEN_ACCESSORS_NAMED(vsatp, CSR_VSATP)
 CSRS_GEN_ACCESSORS_NAMED(hvip, CSR_HVIP)
 CSRS_GEN_ACCESSORS_NAMED(vsie, CSR_VSIE)
-CSRS_GEN_ACCESSORS_NAMED(htimedelta, CSR_HTIMEDELTA)
 CSRS_GEN_ACCESSORS_NAMED(hie, CSR_HIE)
+
+#if (RV64)
+CSRS_GEN_ACCESSORS_NAMED(stimecmp, CSR_STIMECMP)
+CSRS_GEN_ACCESSORS_NAMED(vstimecmp, CSR_VSTIMECMP)
+CSRS_GEN_ACCESSORS_NAMED(henvcfg, CSR_HENVCFG)
+CSRS_GEN_ACCESSORS_NAMED(htimedelta, CSR_HTIMEDELTA)
+#else
+CSRS_GEN_ACCESSORS_NAMED(henvcfgl, CSR_HENVCFG)
+CSRS_GEN_ACCESSORS_NAMED(henvcfgh, CSR_HENVCFGH)
+CSRS_GEN_ACCESSORS_MERGED(henvcfg, henvcfgl, henvcfgh)
+
+CSRS_GEN_ACCESSORS_NAMED(htimedeltal, CSR_HTIMEDELTA)
+CSRS_GEN_ACCESSORS_NAMED(htimedeltah, CSR_HTIMEDELTAH)
+CSRS_GEN_ACCESSORS_MERGED(htimedelta, htimedeltal, htimedeltah)
+
+CSRS_GEN_ACCESSORS_NAMED(stimecmpl, CSR_STIMECMP)
+CSRS_GEN_ACCESSORS_NAMED(stimecmph, CSR_STIMECMPH)
+CSRS_GEN_ACCESSORS_MERGED(stimecmp, stimecmpl, stimecmph)
+
+CSRS_GEN_ACCESSORS_NAMED(vstimecmpl, CSR_VSTIMECMP)
+CSRS_GEN_ACCESSORS_NAMED(vstimecmph, CSR_VSTIMECMPH)
+CSRS_GEN_ACCESSORS_MERGED(vstimecmp, vstimecmpl, vstimecmph)
+#endif
 
 #endif /* __ASSEMBLER__ */
 

--- a/src/arch/riscv/inc/arch/page_table.h
+++ b/src/arch/riscv/inc/arch/page_table.h
@@ -14,12 +14,13 @@
 
 #define PT_SHARED_LVL    (0)
 
-#if (RV64)
-#define PTE_MASK     BIT64_MASK
-#define PTE_ADDR_MSK PTE_MASK(12, 44)
-#elif (RV32)
+#if (RV32)
 #define PTE_MASK     BIT32_MASK
 #define PTE_ADDR_MSK PTE_MASK(12, 22)
+#else
+// This layout assumes Sv39 is available as mandated by the RVA23S64 profile
+#define PTE_MASK     BIT64_MASK
+#define PTE_ADDR_MSK PTE_MASK(12, 44)
 #endif
 
 #define PTE_FLAGS_MSK             PTE_MASK(0, 8)
@@ -70,7 +71,12 @@
 
 #ifndef __ASSEMBLER__
 
+#if (RV32)
+typedef uint32_t pte_t;
+#else
 typedef uint64_t pte_t;
+#endif
+
 typedef pte_t pte_type_t;
 typedef pte_t pte_flags_t;
 

--- a/src/arch/riscv/interrupts.c
+++ b/src/arch/riscv/interrupts.c
@@ -43,7 +43,7 @@ void interrupts_arch_ipi_send(cpuid_t target_cpu, irqid_t ipi_id)
     if (ACLINT_PRESENT()) {
         aclint_send_ipi(target_cpu);
     } else {
-        sbi_send_ipi(1ULL << target_cpu, 0);
+        sbi_send_ipi(1UL << target_cpu, 0);
     }
 }
 

--- a/src/arch/riscv/iommu.c
+++ b/src/arch/riscv/iommu.c
@@ -359,7 +359,8 @@ static void rv_iommu_write_ddt(deviceid_t dev_id, struct vm* vm, paddr_t root_pt
 
         uint64_t iohgatp = 0;
         iohgatp |= ((root_pt >> 12) & RV_IOMMU_DC_IOHGATP_PPN_MASK);
-        iohgatp |= ((vm->id << RV_IOMMU_DC_IOHGATP_GSCID_OFF) & RV_IOMMU_DC_IOHGATP_GSCID_MASK);
+        iohgatp |= ((((uint64_t)vm->id) << RV_IOMMU_DC_IOHGATP_GSCID_OFF) &
+            RV_IOMMU_DC_IOHGATP_GSCID_MASK);
         iohgatp |= RV_IOMMU_IOHGATP_SV39X4;
         rv_iommu.hw.ddt[dev_id].iohgatp = iohgatp;
 

--- a/src/arch/riscv/irqc/plic/vplic.c
+++ b/src/arch/riscv/irqc/plic/vplic.c
@@ -142,7 +142,7 @@ static void vplic_ipi_handler(uint32_t event, uint64_t data)
 {
     switch (event) {
         case UPDATE_HART_LINE:
-            vplic_update_hart_line(cpu()->vcpu, data);
+            vplic_update_hart_line(cpu()->vcpu, (size_t)data);
             break;
         default:
             WARNING("Unknown VPLIC IPI event");

--- a/src/arch/riscv/mem.c
+++ b/src/arch/riscv/mem.c
@@ -62,7 +62,7 @@ bool mem_translate(struct addr_space* as, vaddr_t va, paddr_t* pa)
     }
     if (pte && pte_valid(pte)) {
         *pa = pte_addr(pte);
-        paddr_t mask = (1ULL << as->pt.dscr->lvl_off[lvl]) - 1;
+        paddr_t mask = (paddr_t)(1UL << as->pt.dscr->lvl_off[lvl]) - 1;
         *pa = (*pa & ~mask) | ((paddr_t)va & mask);
         return true;
     } else {

--- a/src/arch/riscv/mem.c
+++ b/src/arch/riscv/mem.c
@@ -26,6 +26,10 @@ static inline void as_map_physical_identity(struct addr_space* as)
         paddr_t top = ALIGN((reg->base + reg->size), lvl_size) & lvl_mask;
         size_t num_entries = ((top - base - 1) / lvl_size) + 1;
 
+        if ((RV32) && ((reg->base + reg->size - 1) >= BAO_VAS_BASE)) {
+            ERROR("Physical memory layout not supported for RV32. FIXME!");
+        }
+
         paddr_t addr = base;
         for (unsigned int j = 0; j < num_entries; j++) {
             size_t index = pt_getpteindex_by_va(&as->pt, (vaddr_t)addr, lvl);

--- a/src/arch/riscv/page_table.c
+++ b/src/arch/riscv/page_table.c
@@ -6,12 +6,13 @@
 #include <bao.h>
 #include <page_table.h>
 
-#if (SV32)
-struct page_table_dscr sv32_pt_dscr = { .lvls = 2,
+#if (RV32)
+struct page_table_dscr sv32_pt_dscr = {
+    .lvls = 2,
     .lvl_wdt = (size_t[]){ 32, 22 },
     .lvl_off = (size_t[]){ 22, 12 },
-    .lvl_term = (bool[]){ true, true } },
-                       ;
+    .lvl_term = (bool[]){ true, true },
+};
 struct page_table_dscr sv32x4_pt_dscr = {
     .lvls = 2,
     .lvl_wdt = (size_t[]){ 34, 22 },
@@ -19,7 +20,7 @@ struct page_table_dscr sv32x4_pt_dscr = {
     .lvl_term = (bool[]){ true, true },
 };
 struct page_table_dscr* hyp_pt_dscr = &sv32_pt_dscr;
-struct page_table_dscr* vm_pt_dscr = &sv32x2_pt_dscr;
+struct page_table_dscr* vm_pt_dscr = &sv32x4_pt_dscr;
 #elif (RV64)
 struct page_table_dscr sv39_pt_dscr = {
     .lvls = 3,

--- a/src/arch/riscv/relocate.S
+++ b/src/arch/riscv/relocate.S
@@ -38,13 +38,13 @@ switch_space:
     li a4, 0
 1:
     /* Copy two words */
-    ld a2, (a6)
-    sd a2, (a0)
+    LOAD a2, (a6)
+    STORE a2, (a0)
     
     /* Increment addressess and count accordingly */
-    add a6, a6, 8
-    add a0, a0, 8
-    add a4, a4, 8
+    add a6, a6, REGLEN
+    add a0, a0, REGLEN
+    add a4, a4, REGLEN
     
     /* If count is less then size, repeat */
     blt a4, a5, 1b

--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -46,6 +46,9 @@ void vcpu_arch_reset(struct vcpu* vcpu, vaddr_t entry)
 
     if (CPU_HAS_EXTENSION(CPU_EXT_SSTC)) {
         csrs_stimecmp_write(~0U);
+        csrs_henvcfg_set(HENVCFG_STCE);
+    } else {
+        csrs_henvcfg_clear(HENVCFG_STCE);
     }
 
     csrs_hcounteren_write(HCOUNTEREN_TM);

--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -38,7 +38,10 @@ void vcpu_arch_reset(struct vcpu* vcpu, vaddr_t entry)
 
     csrs_sscratch_write((uintptr_t)&vcpu->regs);
 
-    vcpu->regs.hstatus = HSTATUS_SPV | HSTATUS_VSXL_64;
+    vcpu->regs.hstatus = HSTATUS_SPV;
+    if (RV64) {
+        vcpu->regs.hstatus |= HSTATUS_VSXL_64;
+    }
     vcpu->regs.sstatus = SSTATUS_SPP_BIT | SSTATUS_FS_DIRTY | SSTATUS_XS_DIRTY;
     vcpu->regs.sepc = entry;
     vcpu->regs.a0 = vcpu->arch.hart_id = vcpu->id;

--- a/src/platform/qemu-riscv32-virt/inc
+++ b/src/platform/qemu-riscv32-virt/inc
@@ -1,0 +1,1 @@
+../qemu-riscv64-virt/inc

--- a/src/platform/qemu-riscv32-virt/objects.mk
+++ b/src/platform/qemu-riscv32-virt/objects.mk
@@ -1,0 +1,1 @@
+../qemu-riscv64-virt/objects.mk

--- a/src/platform/qemu-riscv32-virt/platform.mk
+++ b/src/platform/qemu-riscv32-virt/platform.mk
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+ARCH_SUB:=riscv32
+include $(current_directory)/../qemu-riscv64-virt/platform.mk

--- a/src/platform/qemu-riscv32-virt/virt_desc.c
+++ b/src/platform/qemu-riscv32-virt/virt_desc.c
@@ -1,0 +1,1 @@
+../qemu-riscv64-virt/virt_desc.c

--- a/src/platform/qemu-riscv64-virt/virt_desc.c
+++ b/src/platform/qemu-riscv64-virt/virt_desc.c
@@ -6,6 +6,15 @@
 #include <platform.h>
 #include <interrupts.h>
 
+#if RV32
+// We use only 1 GiB for the rv32, due to limitations on how the physical memory must
+// be identity mapped by the hypervisor and the fact that the hypervisor reserves for
+// itsel the upper GB of the 4GB address space.
+#define QEMU_VIRT_MEM_REG_SIZE (0x40000000 - 0x200000)
+#else
+#define QEMU_VIRT_MEM_REG_SIZE (0x100000000 - 0x200000)
+#endif
+
 struct platform platform = {
 
     .cpu_num = 4,
@@ -14,7 +23,7 @@ struct platform platform = {
     .regions =  (struct mem_region[]) {
         {
             .base = 0x80200000,
-            .size = 0x100000000 - 0x200000,
+            .size = QEMU_VIRT_MEM_REG_SIZE,
         },
     },
 


### PR DESCRIPTION
This PR introduces support for RV32. Because the way the instruction set is written the difference is not much when comparing to RV64. The main areas of modification are:

- modifying assembly instructions that used 64-bit load/store directly by the LOAD/STORE macro which translates to either ld/st or lw/sw depending on if we are targetting RV64 or RV32, respectively;
- support for the sv32 translation mode. This also requires adapting the boot code where the bootstrap page-tables are built manually.
- adapt CSR access to CSRs that have a H variant (e.g., henvcfg, henvcfgh), and other small related issues;
- fix small issues that assumed 64-bit literals.

The PR also includes support for qemu-system-riscv32 virt machine, which is essentially a wrapper over the 64-bit variant.

The main issue with this port is related to the fact that we are required to map all available physical memory to perform page-table walks. Because the address space is so small (4GiB), this might not be possible as for RV64 we simply identity map all physical memory and assume these addresses won't collide with the high virtual addresses used by the hypervisor. This is not the case and we might not be able to map all physical addresses, which already happens for qemu-riscv32-virt if we configure it with memory larger than 1 GiB, since it starts memory at 0x80000000. We might need a dynamic mechanism similar to Linux's "highmem" in the future. I only think this is worth it if a real platform that requires it becomes available. Also, the main purpose of supporting RV32 is to target future MMU-less systems.

Test guest:
- [x]  Baremetal app
- [x] Linux

Depends on #115 