### PR TITLE
Add compatibility with standard C11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ ifeq ($(DEBUG), y)
 	OPTIMIZATIONS:=g
 endif
 
-override CFLAGS+=-O$(OPTIMIZATIONS) -Wall -Werror -ffreestanding -std=gnu11 \
+override CFLAGS+=-O$(OPTIMIZATIONS) -Wall -Werror -ffreestanding -std=c11 -pedantic -pedantic-errors \
 	-fno-pic $(arch-cflags) $(platform-cflags) $(CPPFLAGS) $(debug_flags)
 
 override ASFLAGS+=$(CFLAGS) $(arch-asflags) $(platform-asflags)


### PR DESCRIPTION
## PR description

The usage of a C standard without any extensions is a required rule in MISRA compliance.
This PR will serve as a hub for most modifications regarding the standard C11 and additonal MISRA rules that can be verified by the compiler.
Ideally, each PR made to this WIP will represent a rule or a subset of MISRA rules that are verified with additional compiling flags.

- [ ] C11 with no extensions
- [ ] TBD