### PR TITLE
fix(plat/drivers): add missing uart_putc function prototype

### DIFF
--- a/src/platform/drivers/8250_uart/inc/drivers/8250_uart.h
+++ b/src/platform/drivers/8250_uart/inc/drivers/8250_uart.h
@@ -64,5 +64,6 @@ typedef struct uart8250_hw bao_uart_t;
 
 void uart_enable(volatile struct uart8250_hw* uart);
 void uart_init(volatile struct uart8250_hw* uart);
+void uart_putc(volatile struct uart8250_hw* uart, int8_t c);
 
 #endif /* UART8250_H */

--- a/src/platform/drivers/nxp_uart/inc/drivers/nxp_uart.h
+++ b/src/platform/drivers/nxp_uart/inc/drivers/nxp_uart.h
@@ -33,4 +33,5 @@ typedef struct lpuart bao_uart_t;
 
 void uart_enable(volatile struct lpuart* uart);
 void uart_init(volatile struct lpuart* uart);
+void uart_putc(volatile struct lpuart* uart, char c);
 #endif /* __UART_NXP_H */


### PR DESCRIPTION
Add missing uart_putc function prototype to 8250_uart.h and nxp_uart.h files.