### PR TITLE
feat(core/shmem): move shared memory logic to dedicated source file

### DIFF
--- a/src/core/inc/ipc.h
+++ b/src/core/inc/ipc.h
@@ -21,6 +21,5 @@ struct vm_config;
 
 long int ipc_hypercall(unsigned long arg0, unsigned long arg1, unsigned long arg2);
 void ipc_init(void);
-struct shmem* ipc_get_shmem(size_t shmem_id);
 
 #endif /* IPC_H */

--- a/src/core/inc/shmem.h
+++ b/src/core/inc/shmem.h
@@ -1,0 +1,14 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef SHMEM_H
+#define SHMEM_H
+
+#include <mem.h>
+
+void shmem_init(void);
+struct shmem* shmem_get(size_t shmem_id);
+
+#endif /* SHMEM_H */

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -9,6 +9,7 @@
 #include <vmm.h>
 #include <hypercall.h>
 #include <config.h>
+#include <shmem.h>
 
 enum { IPC_NOTIFY };
 
@@ -19,18 +20,6 @@ union ipc_msg_data {
     };
     uint64_t raw;
 };
-
-static size_t shmem_table_size;
-static struct shmem* shmem_table;
-
-struct shmem* ipc_get_shmem(size_t shmem_id)
-{
-    if (shmem_id < shmem_table_size) {
-        return &shmem_table[shmem_id];
-    } else {
-        return NULL;
-    }
-}
 
 static struct ipc* ipc_find_by_shmemid(struct vm* vm, size_t shmem_id)
 {
@@ -78,7 +67,7 @@ long int ipc_hypercall(unsigned long ipc_id, unsigned long ipc_event, unsigned l
     struct shmem* shmem = NULL;
     bool valid_ipc_obj = ipc_id < cpu()->vcpu->vm->ipc_num;
     if (valid_ipc_obj) {
-        shmem = ipc_get_shmem(cpu()->vcpu->vm->ipcs[ipc_id].shmem_id);
+        shmem = shmem_get(cpu()->vcpu->vm->ipcs[ipc_id].shmem_id);
     }
     bool valid_shmem = shmem != NULL;
 
@@ -102,32 +91,4 @@ long int ipc_hypercall(unsigned long ipc_id, unsigned long ipc_event, unsigned l
     }
 
     return ret;
-}
-
-static void ipc_alloc_shmem()
-{
-    for (size_t i = 0; i < shmem_table_size; i++) {
-        struct shmem* shmem = &shmem_table[i];
-        if (!shmem->place_phys) {
-            size_t n_pg = NUM_PAGES(shmem->size);
-            struct ppages ppages = mem_alloc_ppages(shmem->colors, n_pg, false);
-            if (ppages.num_pages < n_pg) {
-                ERROR("failed to allocate shared memory");
-            }
-            shmem->phys = ppages.base;
-        }
-    }
-}
-
-void ipc_init(void)
-{
-    if (cpu_is_master()) {
-        shmem_table_size = config.shmemlist_size;
-        shmem_table = config.shmemlist;
-        ipc_alloc_shmem();
-
-        for (size_t i = 0; i < config.shmemlist_size; i++) {
-            config.shmemlist[i].cpu_masters = 0;
-        }
-    }
 }

--- a/src/core/objects.mk
+++ b/src/core/objects.mk
@@ -13,3 +13,4 @@ core-objs-y+=console.o
 core-objs-y+=ipc.o
 core-objs-y+=objpool.o
 core-objs-y+=hypercall.o
+core-objs-y+=shmem.o

--- a/src/core/shmem.c
+++ b/src/core/shmem.c
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <shmem.h>
+#include <config.h>
+
+static size_t shmem_table_size;
+static struct shmem* shmem_table;
+
+static void shmem_alloc()
+{
+    for (size_t i = 0; i < shmem_table_size; i++) {
+        struct shmem* shmem = &shmem_table[i];
+        if (!shmem->place_phys) {
+            size_t n_pg = NUM_PAGES(shmem->size);
+            struct ppages ppages = mem_alloc_ppages(shmem->colors, n_pg, false);
+            if (ppages.num_pages < n_pg) {
+                ERROR("failed to allocate shared memory");
+            }
+            shmem->phys = ppages.base;
+        }
+    }
+}
+
+struct shmem* shmem_get(size_t shmem_id)
+{
+    if (shmem_id < shmem_table_size) {
+        return &shmem_table[shmem_id];
+    } else {
+        return NULL;
+    }
+}
+
+void shmem_init()
+{
+    if (cpu_is_master()) {
+        shmem_table_size = config.shmemlist_size;
+        shmem_table = config.shmemlist;
+        shmem_alloc();
+
+        for (size_t i = 0; i < config.shmemlist_size; i++) {
+            config.shmemlist[i].cpu_masters = 0;
+        }
+    }
+}

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -8,6 +8,7 @@
 #include <mem.h>
 #include <cache.h>
 #include <config.h>
+#include <shmem.h>
 
 static void vm_master_init(struct vm* vm, const struct vm_config* vm_config, vmid_t vm_id)
 {
@@ -166,7 +167,7 @@ static void vm_init_ipc(struct vm* vm, const struct vm_config* vm_config)
     vm->ipcs = vm_config->platform.ipcs;
     for (size_t i = 0; i < vm_config->platform.ipc_num; i++) {
         struct ipc* ipc = &vm_config->platform.ipcs[i];
-        struct shmem* shmem = ipc_get_shmem(ipc->shmem_id);
+        struct shmem* shmem = shmem_get(ipc->shmem_id);
         if (shmem == NULL) {
             WARNING("Invalid shmem id in configuration. Ignored.");
             continue;

--- a/src/core/vmm.c
+++ b/src/core/vmm.c
@@ -10,7 +10,7 @@
 #include <spinlock.h>
 #include <fences.h>
 #include <string.h>
-#include <ipc.h>
+#include <shmem.h>
 
 static struct vm_assignment {
     spinlock_t lock;
@@ -127,7 +127,7 @@ void vmm_init()
 {
     vmm_arch_init();
     vmm_io_init();
-    ipc_init();
+    shmem_init();
 
     cpu_sync_barrier(&cpu_glb_sync);
 


### PR DESCRIPTION
This patch relocates the initialization and shared memory access steps from the hardcoded settings in the existing IPC file to a generic shared memory file. Previously, the code assumed the existence of only one object working with the shared memory (ipc). With this update, the system is now prepared for future versions where multiple objects can be added and working with the shared memory.