### PR TITLE
fix(armv8/gic): correct GICH_MISR_LRENP

### DIFF
--- a/src/arch/armv8/inc/arch/gic.h
+++ b/src/arch/armv8/inc/arch/gic.h
@@ -328,7 +328,7 @@ typedef uint64_t gic_lr_t;
 
 #define GICH_MISR_EOI         (1U << 0)
 #define GICH_MISR_U           (1U << 1)
-#define GICH_MISR_LRPEN       (1U << 2)
+#define GICH_MISR_LRENP       (1U << 2)
 #define GICH_MISR_NP          (1U << 3)
 #define GICH_MISR_VGrp0E      (1U << 4)
 #define GICH_MISR_VGrp0D      (1U << 5)

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -1092,7 +1092,7 @@ void gic_maintenance_handler(irqid_t irq_id)
         vgic_refill_lrs(cpu()->vcpu, !!(misr & GICH_MISR_NP));
     }
 
-    if (misr & GICH_MISR_LRPEN) {
+    if (misr & GICH_MISR_LRENP) {
         uint32_t hcr_el2 = gich_get_hcr();
         while (hcr_el2 & GICH_HCR_EOICount_MASK) {
             vgic_eoir_highest_spilled_active(cpu()->vcpu);


### PR DESCRIPTION
According to GIC architecture specification, GICH_MISR[2] is called LRENP, which represents list register entry not present maintenance interrupt.