### PR TITLE
Fix aarch32 vm install

### DIFF
--- a/src/arch/armv8/armv8-a/aarch32/inc/arch/bao.h
+++ b/src/arch/armv8/armv8-a/aarch32/inc/arch/bao.h
@@ -6,14 +6,15 @@
 #ifndef __ARCH_BAO_H__
 #define __ARCH_BAO_H__
 
-#define BAO_VAS_BASE (0x40000000)
-#define BAO_CPU_BASE (0x50000000)
-#define BAO_VM_BASE  (0x60000000)
-#define BAO_VAS_TOP  (0x80000000)
-#define PAGE_SIZE    (0x1000)
-#define STACK_SIZE   (PAGE_SIZE)
+#define BAO_VAS_BASE     (0x40000000)
+#define BAO_CPU_BASE     (0x50000000)
+#define BAO_VM_BASE      (0x60000000)
+#define BAO_VAS_TOP      (0x80000000)
+#define PAGE_SIZE        (0x1000)
+#define STACK_SIZE       (PAGE_SIZE)
+#define VM_SHARED_PT_LVL (1)
 
-#define GPR(N)       "r" #N
+#define GPR(N)           "r" #N
 
 #ifndef __ASSEMBLER__
 

--- a/src/arch/armv8/armv8-a/aarch64/inc/arch/bao.h
+++ b/src/arch/armv8/armv8-a/aarch64/inc/arch/bao.h
@@ -6,14 +6,15 @@
 #ifndef __ARCH_BAO_H__
 #define __ARCH_BAO_H__
 
-#define BAO_VAS_BASE (0xfd8000000000)
-#define BAO_CPU_BASE (0xfe0000000000)
-#define BAO_VM_BASE  (0xfe8000000000)
-#define BAO_VAS_TOP  (0xff0000000000)
-#define PAGE_SIZE    (0x1000)
-#define STACK_SIZE   (PAGE_SIZE)
+#define BAO_VAS_BASE     (0xfd8000000000)
+#define BAO_CPU_BASE     (0xfe0000000000)
+#define BAO_VM_BASE      (0xfe8000000000)
+#define BAO_VAS_TOP      (0xff0000000000)
+#define PAGE_SIZE        (0x1000)
+#define STACK_SIZE       (PAGE_SIZE)
+#define VM_SHARED_PT_LVL (0)
 
-#define GPR(N)       "x" #N
+#define GPR(N)           "x" #N
 
 #ifndef __ASSEMBLER__
 

--- a/src/arch/riscv/inc/arch/bao.h
+++ b/src/arch/riscv/inc/arch/bao.h
@@ -39,8 +39,9 @@
 #define BAO_VAS_TOP  (0xffffffff)
 #endif
 
-#define PAGE_SIZE  (0x1000)
-#define STACK_SIZE (PAGE_SIZE)
+#define PAGE_SIZE        (0x1000)
+#define STACK_SIZE       (PAGE_SIZE)
+#define VM_SHARED_PT_LVL (0)
 
 #ifndef __ASSEMBLER__
 

--- a/src/core/mmu/vmm.c
+++ b/src/core/mmu/vmm.c
@@ -16,14 +16,14 @@ struct vm_install_info vmm_get_vm_install_info(struct vm_allocation* vm_alloc)
 {
     struct vm_install_info info = {
         .base = vm_alloc->base,
-        .vm_section_pte = *pt_get_pte(&cpu()->as.pt, 0, vm_alloc->base),
+        .vm_section_pte = *pt_get_pte(&cpu()->as.pt, VM_SHARED_PT_LVL, vm_alloc->base),
     };
     return info;
 }
 
 void vmm_vm_install(struct vm_install_info* install_info)
 {
-    pte_t* pte = pt_get_pte(&cpu()->as.pt, 0, (vaddr_t)install_info->base);
+    pte_t* pte = pt_get_pte(&cpu()->as.pt, VM_SHARED_PT_LVL, (vaddr_t)install_info->base);
     *pte = install_info->vm_section_pte;
     // We don't invalidate the TLB as we know there was no previous mapping or accesses to the
     // addresses in the VM section. Just make sure the write commited before leaving.


### PR DESCRIPTION
The level of page table where entries are shared for aarch32 is lvl 1. By resharing the lvl 0 pte, this was causing erroneous mappings on secondary cores.

Depends on https://github.com/bao-project/bao-hypervisor/pull/114