### PR TITLE
fix(armv8/vgic): fix comparison on pend_found

### DIFF
--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -360,7 +360,7 @@ bool vgic_add_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
             }
         }
 
-        if (pend_found > 1) {
+        if (pend_found >= 1) {
             lr_ind = pend_ind;
         } else {
             lr_ind = act_ind;


### PR DESCRIPTION
If a suitable pending interrupt is found, it should be replaced rather than checking if `pend_found` is greater than 1. Thus, I have changed `> 1` to `>= 1`.
If my understanding is incorrect, I will close this PR. Thank you for your review!