### PR TITLE
Allow for ci submodule not be present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ scripts_dir:=$(cur_dir)/scripts
 ci_dir:=$(cur_dir)/ci
 src_dirs:=
 
-include $(ci_dir)/ci.mk
+-include $(ci_dir)/ci.mk
 
 targets:=$(MAKECMDGOALS)
 ifeq ($(targets),)
@@ -327,6 +327,8 @@ clean:
 
 # Instantiate CI rules
 
+ifneq ($(wildcard $(ci_dir)/ci.mk),)
+
 all_files= $(realpath \
 	$(cur_dir)/Makefile \
 	$(call list_dir_files_recursive, $(src_dir), *) \
@@ -342,3 +344,5 @@ $(call ci, format, $(all_c_files))
 
 .PHONY: ci
 ci: license-check format-check
+
+endif


### PR DESCRIPTION
If this reposiroty is not cloned with '--recursive', the ci subdmoudle will not be prenset which will result in any invocation of make to fail. This modification allows that if the ci submodule is not present, it will simply be ignored and typical make calls for building the hypervisor will continue normally.