### PR TITLE
fix(sysreg): Fix generation of ccsdr_el1 assessors

### DIFF
--- a/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
+++ b/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
@@ -83,9 +83,8 @@ SYSREG_GEN_ACCESSORS(cptr_el2, 4, c1, c1, 2)   // hcptr
 SYSREG_GEN_ACCESSORS(vtcr_el2, 4, c2, c1, 2)
 SYSREG_GEN_ACCESSORS_64(vttbr_el2, 6, c2)
 SYSREG_GEN_ACCESSORS(tpidr_el2, 4, c13, c0, 2) // htpidr
-SYSREG_GEN_ACCESSORS(ccsidr, 1, c0, c0, 0)
+SYSREG_GEN_ACCESSORS(ccsidr_el1, 1, c0, c0, 0)
 SYSREG_GEN_ACCESSORS(ccsidr2, 1, c0, c0, 2)
-SYSREG_GEN_ACCESSORS_MERGE(ccsidr_el1, ccsidr, ccsidr2)
 SYSREG_GEN_ACCESSORS(hmair0, 4, c10, c2, 0)
 SYSREG_GEN_ACCESSORS(hmair1, 4, c10, c2, 1)
 SYSREG_GEN_ACCESSORS_MERGE(mair_el2, hmair0, hmair1)


### PR DESCRIPTION
## PR Description

The changes in commit eb64e58637b9ed8e52a907496052f40f6e7f5d25 prevented bao from executing in fvp-a-aarch32.
This PR reverts the modifications that caused the error.

