### PR TITLE
fix(ipc): inject non-hw interupt

### DIFF
--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -40,7 +40,7 @@ static void ipc_notify(size_t shmem_id, size_t event_id)
     struct ipc* ipc_obj = ipc_find_by_shmemid(cpu()->vcpu->vm, shmem_id);
     if (ipc_obj != NULL && event_id < ipc_obj->interrupt_num) {
         irqid_t irq_id = ipc_obj->interrupts[event_id];
-        vcpu_inject_hw_irq(cpu()->vcpu, irq_id);
+        vcpu_inject_irq(cpu()->vcpu, irq_id);
     }
 }
 


### PR DESCRIPTION
The IPC module was injecting the IPC object interrupt as an hardware interrupt by default using `vcpu_inject_hw_irq`. However, this interrupt is purely virtual since it does not have a counterpart in hardware and the way bao handles the two kinds of interrupts is different, especially on the arm architecture.

This PR fixes it by calling the more generic `vcpu_inject_irq` which internally decides if it should inject it as a virtual interrupt or virtual.