### PR TITLE
Fix RISC-V SBI return values

### DIFF
--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -404,7 +404,10 @@ static struct sbiret sbi_bao_handler(unsigned long fid)
 {
     struct sbiret ret;
 
-    ret.error = hypercall(fid);
+    // Any hypercall will always be successful from a purely SBI standpoint. A
+    // bao-specific hypercall code is returned as the value.
+    ret.error = SBI_SUCCESS;
+    ret.value = hypercall(fid);
 
     return ret;
 }

--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -436,7 +436,7 @@ size_t sbi_vs_handler()
             break;
         default:
             WARNING("guest issued unsupport sbi extension call (%d)", extid);
-            ret.value = SBI_ERR_NOT_SUPPORTED;
+            ret.error = SBI_ERR_NOT_SUPPORTED;
     }
 
     vcpu_writereg(cpu()->vcpu, REG_A0, (unsigned long)ret.error);


### PR DESCRIPTION
This PR fixes a couple return values on the SBI code.

First, when the call was not supported this was being returned in value, not error.

Then, the hypercall specific error code was being returned as an sbi error. However, it is best to maintain the error code as a standard sbi return value and return the bao-specific hypercall return in the value field.