### PR TITLE
Fix(rv32_conversions): Fix errors with literal sizes

### DIFF
--- a/src/arch/riscv/inc/arch/csrs.h
+++ b/src/arch/riscv/inc/arch/csrs.h
@@ -104,7 +104,7 @@
 #define SSTATUS_XS_DIRTY            (3ULL << SSTATUS_XS_OFF)
 #define SSTATUS_SUM                 (1ULL << 18)
 #define SSTATUS_MXR                 (1ULL << 19)
-#define SSTATUS_SD                  (1ULL << 63)
+#define SSTATUS_SD                  (1ULL << ((REGLEN * 8) - 1))
 
 #define SIE_USIE                    (1ULL << 0)
 #define SIE_SSIE                    (1ULL << 1)

--- a/src/arch/riscv/irqc/aia/imsic.c
+++ b/src/arch/riscv/irqc/aia/imsic.c
@@ -53,7 +53,7 @@ void imsic_init(void)
 void imsic_set_enbl(irqid_t intp_id)
 {
     csrs_siselect_write(IMSIC_EIE + imsic_eie_index(intp_id));
-    csrs_sireg_set(1ULL << imsic_eie_bit(intp_id));
+    csrs_sireg_set(1UL << imsic_eie_bit(intp_id));
 }
 
 bool imsic_get_pend(irqid_t intp_id)
@@ -65,7 +65,7 @@ bool imsic_get_pend(irqid_t intp_id)
 void imsic_clr_pend(irqid_t intp_id)
 {
     csrs_siselect_write(IMSIC_EIP + imsic_eie_index(intp_id));
-    csrs_sireg_clear(1ULL << imsic_eie_bit(intp_id));
+    csrs_sireg_clear(1UL << imsic_eie_bit(intp_id));
 }
 
 /**
@@ -77,7 +77,7 @@ void imsic_inject_pend(size_t guest_file, irqid_t intp_id)
     UNUSED_ARG(guest_file);
 
     csrs_vsiselect_write(IMSIC_EIP + imsic_eie_index(intp_id));
-    csrs_vsireg_clear(1ULL << imsic_eie_bit(intp_id));
+    csrs_vsireg_clear(1UL << imsic_eie_bit(intp_id));
 }
 
 void imsic_send_msi(cpuid_t target_cpu, irqid_t ipi_id)


### PR DESCRIPTION
## PR Description

The PR https://github.com/bao-project/bao-hypervisor/pull/117 introduced some compiling errors for riscv32 builds. 
This PR fixes those errors, which were related to using 64-bit literals for operations/functions that needed 32-bit values.