### PR TITLE
fix(aarch32/sysregs): fix the 64-bit register read function

### DIFF
--- a/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
+++ b/src/arch/armv8/aarch32/inc/arch/subarch/sysregs.h
@@ -40,7 +40,7 @@
     {                                                                                             \
         unsigned long long _temp, _tempH;                                                         \
         __asm__ volatile("mrrc p15, " #op1 ", %0, %1, " #crm "\n\r" : "=r"(_temp), "=r"(_tempH)); \
-        return ((_tempH << 32) | _temp);                                                          \
+        return ((_tempH << 32) | ((unsigned long)_temp));                                         \
     }                                                                                             \
     static inline void sysreg_##reg##_write(unsigned long long val)                               \
     {                                                                                             \


### PR DESCRIPTION
The usage of `unsigned long long` for both variables may introduce unexpected values in the OR operation in the return statement, as the `_temp`  variable is not guaranteed to be initialized to 0.
