### PR TITLE
fix(core/remio): add missing operator to check pending requests

### DIFF
--- a/src/core/remio.c
+++ b/src/core/remio.c
@@ -206,7 +206,7 @@ static inline struct remio_request* remio_get_request(struct remio_device* devic
  */
 static inline bool remio_has_pending_request(struct remio_device* device)
 {
-    return list_empty(&device->pending_requests_list);
+    return !list_empty(&device->pending_requests_list);
 }
 
 /**


### PR DESCRIPTION
This PR fixes the method responsible for checking pending Remote I/O requests by adding the missing `!` operator to the `list_empty` call.