### PR TITLE
fix(riscv/interrupts): add missing initialization for irqc_timer_int_id

### DIFF
--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -10,6 +10,7 @@
 #include <bit.h>
 #include <fences.h>
 #include <hypercall.h>
+#include <interrupts.h>
 
 #define SBI_EXTID_BASE                  (0x10)
 #define SBI_GET_SBI_SPEC_VERSION_FID    (0)
@@ -499,7 +500,8 @@ void sbi_init()
         }
     }
 
-    if (!interrupts_reserve(TIMR_INT_ID, (irq_handler_t)sbi_timer_irq_handler)) {
+    irqc_timer_int_id = interrupts_reserve(TIMR_INT_ID, (irq_handler_t)sbi_timer_irq_handler);
+    if (irqc_timer_int_id == INVALID_IRQID) {
         ERROR("Failed to reserve SBI TIMR_INT_ID interrupt");
     }
 }


### PR DESCRIPTION
irqc_timer_int_id is the variable representing the ID of the timer interrupt. It is declared in the interrupts.c but is never defined, causing a bug while handling timer interrupts inside the handler for the AIA controller ("no interrupt handler for ID 0").

The irqc_timer_int_id variable is initialized following the same strategy used for interrupts_ipi_id.