### PR TITLE
fix(riscv/imsic): read the right CSR register in imsic_get_pend()

### DIFF
--- a/src/arch/riscv/irqc/aia/imsic.c
+++ b/src/arch/riscv/irqc/aia/imsic.c
@@ -59,7 +59,7 @@ void imsic_set_enbl(irqid_t intp_id)
 bool imsic_get_pend(irqid_t intp_id)
 {
     csrs_siselect_write(IMSIC_EIP + imsic_eie_index(intp_id));
-    return csrs_siselect_read() && (1ULL << imsic_eie_bit(intp_id));
+    return csrs_sireg_read() && (1ULL << imsic_eie_bit(intp_id));
 }
 
 void imsic_clr_pend(irqid_t intp_id)


### PR DESCRIPTION
SISELECT CSR is used for specifying the register that will be accessed by SIREG CSR.
Reading the SISELECT CSR returns the offset of that register instead of its value. SIREG is required for that purpose.