### PR TITLE
fix(objpool): mark objpool func as static to avoid missing symbol at O0

### DIFF
--- a/src/core/inc/objpool.h
+++ b/src/core/inc/objpool.h
@@ -35,7 +35,7 @@ void* objpool_alloc(struct objpool* objpool);
 void* objpool_alloc_with_id(struct objpool* objpool, objpool_id_t* id);
 void objpool_free(struct objpool* objpool, void* obj);
 
-inline void* objpool_get_by_id(struct objpool* objpool, objpool_id_t id)
+static inline void* objpool_get_by_id(struct objpool* objpool, objpool_id_t id)
 {
     if (id < objpool->num) {
         return (void*)((uintptr_t)objpool->pool + (objpool->objsize * id));


### PR DESCRIPTION
## PR Description

Small PR to mark `objpool_get_by_id` as `static inline` to ensure the function is always available in translation units that use it. This prevents linker errors at optimization level 0, where the compiler will throw an undefined reference error regarding that symbol.