### PR TITLE
ref(ipi): Update IPI API to support additional architectures

### DIFF
--- a/src/arch/armv8/interrupts.c
+++ b/src/arch/armv8/interrupts.c
@@ -22,10 +22,11 @@ void interrupts_arch_init()
     gic_init();
 }
 
-void interrupts_arch_ipi_send(cpuid_t target_cpu, irqid_t ipi_id)
+void interrupts_arch_ipi_send(cpuid_t target_cpu)
 {
-    if (ipi_id < GIC_MAX_SGIS) {
-        gic_send_sgi(target_cpu, ipi_id);
+    // This check may be removed? Might be an assert or something
+    if (interrupts_ipi_id < GIC_MAX_SGIS) {
+        gic_send_sgi(target_cpu, interrupts_ipi_id);
     }
 }
 

--- a/src/arch/riscv/interrupts.c
+++ b/src/arch/riscv/interrupts.c
@@ -40,10 +40,8 @@ void interrupts_arch_init()
     csrs_sie_set(SIE_SEIE);
 }
 
-void interrupts_arch_ipi_send(cpuid_t target_cpu, irqid_t ipi_id)
+void interrupts_arch_ipi_send(cpuid_t target_cpu)
 {
-    UNUSED_ARG(ipi_id);
-
     if (USE_ACLINT_IPI()) {
         aclint_send_ipi(target_cpu);
     } else {

--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -63,7 +63,7 @@ void cpu_send_msg(cpuid_t trgtcpu, struct cpu_msg* msg)
     node->msg = *msg;
     list_push(&cpu_if(trgtcpu)->event_list, (node_t*)node);
     fence_sync_write();
-    interrupts_cpu_sendipi(trgtcpu, interrupts_ipi_id);
+    interrupts_cpu_sendipi(trgtcpu);
 }
 
 bool cpu_get_msg(struct cpu_msg* msg)
@@ -113,8 +113,8 @@ void cpu_powerdown(void)
 
 void cpu_standby_wakeup(void)
 {
-    if (interrupts_check(interrupts_ipi_id)) {
-        interrupts_clear(interrupts_ipi_id);
+    if (interrupts_ipi_check()) {
+        interrupts_ipi_clear();
         cpu_msg_handler();
     }
 
@@ -127,8 +127,8 @@ void cpu_standby_wakeup(void)
 
 void cpu_powerdown_wakeup(void)
 {
-    if (interrupts_check(interrupts_ipi_id)) {
-        interrupts_clear(interrupts_ipi_id);
+    if (interrupts_ipi_check()) {
+        interrupts_ipi_clear();
         cpu_msg_handler();
     }
 

--- a/src/core/inc/interrupts.h
+++ b/src/core/inc/interrupts.h
@@ -32,11 +32,11 @@ void interrupts_init(void);
  */
 irqid_t interrupts_reserve(irqid_t pint_id, irq_handler_t handler);
 
-void interrupts_cpu_sendipi(cpuid_t target_cpu, irqid_t ipi_id);
+void interrupts_cpu_sendipi(cpuid_t target_cpu);
 void interrupts_cpu_enable(irqid_t int_id, bool en);
 
-bool interrupts_check(irqid_t int_id);
-void interrupts_clear(irqid_t int_id);
+bool interrupts_ipi_check(void);
+void interrupts_ipi_clear(void);
 
 enum irq_res { HANDLED_BY_HYP, FORWARD_TO_VM };
 enum irq_res interrupts_handle(irqid_t int_id);
@@ -50,8 +50,8 @@ irqid_t interrupts_arch_reserve(irqid_t pint_id);
 void interrupts_arch_enable(irqid_t int_id, bool en);
 bool interrupts_arch_check(irqid_t int_id);
 void interrupts_arch_clear(irqid_t int_id);
-void interrupts_arch_ipi_send(cpuid_t cpu_target, irqid_t ipi_id);
+void interrupts_arch_ipi_send(cpuid_t cpu_target);
 void interrupts_arch_vm_assign(struct vm* vm, irqid_t id);
 bool interrupts_arch_conflict(bitmap_t* interrupt_bitmap, irqid_t id);
-
+void interrupts_arch_ipi_init(void);
 #endif /* __INTERRUPTS_H__ */


### PR DESCRIPTION
## PR Description

This PR introduces small changes to the current IPI API moving the interrupt_ipi_id dependency to the arch implementation. 
It also introduces an additional interface _interrupts_arch_ipi_init_ to support architectures that have different IPI mechanisms (i.e TC4).

Additionally, the current supported architectures were updated to match the new interfaces
