### PR TITLE
ref: Replace hardcoded booleans with named macros

### DIFF
--- a/src/arch/armv8/armv8-a/smmuv2.c
+++ b/src/arch/armv8/armv8-a/smmuv2.c
@@ -182,7 +182,7 @@ ssize_t smmu_alloc_ctxbnk(void)
 {
     spin_lock(&smmu.ctx_lock);
     /* Find a free context bank. */
-    ssize_t nth = bitmap_find_nth(smmu.ctxbank_bitmap, smmu.ctx_num, 1, 0, false);
+    ssize_t nth = bitmap_find_nth(smmu.ctxbank_bitmap, smmu.ctx_num, 1, 0, BITMAP_NOT_SET);
     if (nth >= 0) {
         bitmap_set(smmu.ctxbank_bitmap, (size_t)nth);
     }
@@ -247,7 +247,7 @@ ssize_t smmu_alloc_sme(void)
 {
     spin_lock(&smmu.sme_lock);
     /* Find a free sme. */
-    ssize_t nth = bitmap_find_nth(smmu.sme_bitmap, smmu.sme_num, 1, 0, false);
+    ssize_t nth = bitmap_find_nth(smmu.sme_bitmap, smmu.sme_num, 1, 0, BITMAP_NOT_SET);
     if (nth >= 0) {
         bitmap_set(smmu.sme_bitmap, (size_t)nth);
     }

--- a/src/arch/armv8/armv8-r/mpu.c
+++ b/src/arch/armv8/armv8-r/mpu.c
@@ -40,7 +40,7 @@ static mpid_t mpu_entry_allocate(asid_t asid)
 {
     mpid_t reg_num = INVALID_MPID;
     reg_num = (mpid_t)bitmap_find_nth(cpu()->arch.profile.mpu.allocated_entries,
-        MPU_ARCH_MAX_NUM_ENTRIES, 1, 0, false);
+        MPU_ARCH_MAX_NUM_ENTRIES, 1, 0, BITMAP_NOT_SET);
 
     bitmap_set(cpu()->arch.profile.mpu.allocated_entries, reg_num);
     cpu()->arch.profile.mpu.entry_asid[reg_num] = asid;

--- a/src/arch/armv8/armv8-r/vmm.c
+++ b/src/arch/armv8/armv8-r/vmm.c
@@ -35,7 +35,8 @@ void vmm_arch_profile_init()
 
             timer_freq = (uint32_t)timer_ctl->CNTDIF0;
 
-            mem_unmap(&cpu()->as, (vaddr_t)timer_ctl, sizeof(struct generic_timer_cntctrl), false);
+            mem_unmap(&cpu()->as, (vaddr_t)timer_ctl, sizeof(struct generic_timer_cntctrl),
+                MEM_DONT_FREE_PAGES);
         }
     }
 

--- a/src/arch/armv8/inc/arch/vgic.h
+++ b/src/arch/armv8/inc/arch/vgic.h
@@ -14,6 +14,9 @@ struct vm;
 struct vcpu;
 struct vgic_dscrp;
 
+#define VGIC_GICR_ACCESS     (true)
+#define VGIC_NOT_GICR_ACCESS (false)
+
 /**
  * TODO: optimize the vgic_int struct's size
  */

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -968,7 +968,7 @@ bool vgicd_emul_handler(struct emul_access* acc)
 
     if (vgic_check_reg_alignment(acc, handler_info)) {
         spin_lock(&cpu()->vcpu->vm->arch.vgicd.lock);
-        handler_info->reg_access(acc, handler_info, false, cpu()->vcpu->id);
+        handler_info->reg_access(acc, handler_info, VGIC_NOT_GICR_ACCESS, cpu()->vcpu->id);
         spin_unlock(&cpu()->vcpu->vm->arch.vgicd.lock);
         return true;
     } else {

--- a/src/arch/armv8/vgicv2.c
+++ b/src/arch/armv8/vgicv2.c
@@ -155,7 +155,8 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
         (vaddr_t)platform.arch.gic.gicv_addr, n);
 
     size_t vgic_int_size = vm->arch.vgicd.int_num * sizeof(struct vgic_int);
-    vm->arch.vgicd.interrupts = mem_alloc_page(NUM_PAGES(vgic_int_size), SEC_HYP_VM, false);
+    vm->arch.vgicd.interrupts =
+        mem_alloc_page(NUM_PAGES(vgic_int_size), SEC_HYP_VM, MEM_ALIGN_NOT_REQ);
     if (vm->arch.vgicd.interrupts == NULL) {
         ERROR("failed to alloc vgic");
     }

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -276,7 +276,7 @@ static bool vgicr_emul_handler(struct emul_access* acc)
         struct vcpu* vcpu =
             vgicr_id == cpu()->vcpu->id ? cpu()->vcpu : vm_get_vcpu(cpu()->vcpu->vm, vgicr_id);
         spin_lock(&vcpu->arch.vgic_priv.vgicr.lock);
-        handler_info->reg_access(acc, handler_info, true, vgicr_id);
+        handler_info->reg_access(acc, handler_info, VGIC_GICR_ACCESS, vgicr_id);
         spin_unlock(&vcpu->arch.vgic_priv.vgicr.lock);
         return true;
     } else {
@@ -331,7 +331,8 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
     vm->arch.vgicd.lock = SPINLOCK_INITVAL;
 
     size_t vgic_int_size = vm->arch.vgicd.int_num * sizeof(struct vgic_int);
-    vm->arch.vgicd.interrupts = mem_alloc_page(NUM_PAGES(vgic_int_size), SEC_HYP_VM, false);
+    vm->arch.vgicd.interrupts =
+        mem_alloc_page(NUM_PAGES(vgic_int_size), SEC_HYP_VM, MEM_ALIGN_NOT_REQ);
     if (vm->arch.vgicd.interrupts == NULL) {
         ERROR("failed to alloc vgic");
     }

--- a/src/arch/riscv/iommu.c
+++ b/src/arch/riscv/iommu.c
@@ -274,7 +274,7 @@ static void rv_iommu_init(void)
 
     // Allocate memory for FQ (aligned to 4kiB)
     vaddr_t fq_vaddr = (vaddr_t)mem_alloc_page(NUM_PAGES(sizeof(struct fq_entry) * FQ_N_ENTRIES),
-        SEC_HYP_GLOBAL, true);
+        SEC_HYP_GLOBAL, MEM_ALIGN_REQ);
     memset((void*)fq_vaddr, 0, sizeof(struct fq_entry) * FQ_N_ENTRIES);
     rv_iommu.hw.fq = (struct fq_entry*)fq_vaddr;
 
@@ -302,7 +302,7 @@ static void rv_iommu_init(void)
 
     // Allocate a page of memory (aligned) for the DDT
     vaddr_t ddt_vaddr = (vaddr_t)mem_alloc_page(NUM_PAGES(sizeof(struct ddt_entry) * DDT_N_ENTRIES),
-        SEC_HYP_GLOBAL, true);
+        SEC_HYP_GLOBAL, MEM_ALIGN_REQ);
     // Clear entries
     memset((void*)ddt_vaddr, 0, sizeof(struct ddt_entry) * DDT_N_ENTRIES);
     rv_iommu.hw.ddt = (struct ddt_entry*)ddt_vaddr;

--- a/src/arch/riscv/irqc/aia/imsic.c
+++ b/src/arch/riscv/irqc/aia/imsic.c
@@ -102,7 +102,7 @@ irqid_t imsic_allocate_msi(void)
     irqid_t msi_id = INVALID_IRQID;
 
     spin_lock(&msi_alloc_lock);
-    ssize_t bit = bitmap_find_nth(msi_reserved, PLAT_IMSIC_MAX_INTERRUPTS, 1, 0, 0);
+    ssize_t bit = bitmap_find_nth(msi_reserved, PLAT_IMSIC_MAX_INTERRUPTS, 1, 0, BITMAP_NOT_SET);
     if (bit >= 0) {
         msi_id = (irqid_t)bit;
         bitmap_set(msi_reserved, msi_id);

--- a/src/core/inc/mem.h
+++ b/src/core/inc/mem.h
@@ -15,6 +15,12 @@
 
 #ifndef __ASSEMBLER__
 
+#define MEM_ALIGN_REQ       (true)
+#define MEM_ALIGN_NOT_REQ   (false)
+
+#define MEM_FREE_PAGES      (true)
+#define MEM_DONT_FREE_PAGES (false)
+
 enum MEM_PERMISSIONS {
     MEM_RWX = 0, // This variant always has to be zero and therefore the first one
     MEM_RX,

--- a/src/core/mem.c
+++ b/src/core/mem.c
@@ -89,7 +89,8 @@ bool pp_alloc(struct page_pool* pool, size_t num_pages, bool aligned, struct ppa
      */
     for (size_t i = 0; i < 2 && !ok; i++) {
         while (pool->free != 0) {
-            ssize_t bit = bitmap_find_consec(pool->bitmap, pool->num_pages, curr, num_pages, false);
+            ssize_t bit =
+                bitmap_find_consec(pool->bitmap, pool->num_pages, curr, num_pages, BITMAP_NOT_SET);
 
             if (bit < 0) {
                 /**

--- a/src/core/objpool.c
+++ b/src/core/objpool.c
@@ -17,7 +17,7 @@ void* objpool_alloc_with_id(struct objpool* objpool, objpool_id_t* id)
 {
     void* obj = NULL;
     spin_lock(&objpool->lock);
-    ssize_t n = bitmap_find_nth(objpool->bitmap, objpool->num, 1, 0, false);
+    ssize_t n = bitmap_find_nth(objpool->bitmap, objpool->num, 1, 0, BITMAP_NOT_SET);
     if (n >= 0) {
         bitmap_set(objpool->bitmap, (size_t)n);
         obj = (void*)((uintptr_t)objpool->pool + (objpool->objsize * (size_t)n));

--- a/src/core/shmem.c
+++ b/src/core/shmem.c
@@ -16,7 +16,7 @@ static void shmem_alloc(void)
         shmem->lock = SPINLOCK_INITVAL;
         if (!shmem->place_phys) {
             size_t n_pg = NUM_PAGES(shmem->size);
-            struct ppages ppages = mem_alloc_ppages(shmem->colors, n_pg, false);
+            struct ppages ppages = mem_alloc_ppages(shmem->colors, n_pg, MEM_ALIGN_NOT_REQ);
             if (ppages.num_pages < n_pg) {
                 ERROR("failed to allocate shared memory");
             }

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -135,8 +135,8 @@ static void vm_install_image(struct vm* vm, struct vm_mem_region* reg)
         mem_map_cpy(&vm->as, &cpu()->as, vm->config->image.base_addr, INVALID_VA, img_num_pages);
     memcpy((void*)dst_va, (void*)src_va, vm->config->image.size);
     cache_flush_range((vaddr_t)dst_va, vm->config->image.size);
-    mem_unmap(&cpu()->as, src_va, img_num_pages, false);
-    mem_unmap(&cpu()->as, dst_va, img_num_pages, false);
+    mem_unmap(&cpu()->as, src_va, img_num_pages, MEM_DONT_FREE_PAGES);
+    mem_unmap(&cpu()->as, dst_va, img_num_pages, MEM_DONT_FREE_PAGES);
 }
 
 static void vm_map_img_rgn(struct vm* vm, const struct vm_config* vm_config,

--- a/src/core/vmm.c
+++ b/src/core/vmm.c
@@ -90,7 +90,7 @@ static bool vmm_alloc_vm(struct vm_allocation* vm_alloc, struct vm_config* vm_co
     total_size = vcpus_offset + (vm_config->platform.cpu_num * sizeof(struct vcpu));
     total_size = ALIGN(total_size, PAGE_SIZE);
 
-    void* allocation = mem_alloc_page(NUM_PAGES(total_size), SEC_HYP_VM, false);
+    void* allocation = mem_alloc_page(NUM_PAGES(total_size), SEC_HYP_VM, MEM_ALIGN_NOT_REQ);
     if (allocation == NULL) {
         return false;
     }

--- a/src/lib/inc/bitmap.h
+++ b/src/lib/inc/bitmap.h
@@ -27,6 +27,9 @@ static const bitmap_granule_t ONE = 1;
 
 #define BITMAP_ALLOC_ARRAY(NAME, SIZE, NUM) bitmap_granule_t NAME[NUM][BITMAP_SIZE_IN_GRANULE(SIZE)]
 
+#define BITMAP_SET                          (true)
+#define BITMAP_NOT_SET                      (false)
+
 static inline void bitmap_set(bitmap_t* map, size_t bit)
 {
     map[bit / BITMAP_GRANULE_LEN] |= ONE << (bit % BITMAP_GRANULE_LEN);


### PR DESCRIPTION
This commit updates mainly memory and bitmap operations to use named macros like MEM_DONT_FREE_PAGES, MEM_ALIGN_PPAGES, and BITMAP_DONT_SET instead of raw boolean values on respective functions.