### PR TITLE
fix(rv32): use ul for sbi_send_ipi call

### DIFF
--- a/src/arch/riscv/irqc/aia/inc/irqc.h
+++ b/src/arch/riscv/irqc/aia/inc/irqc.h
@@ -68,7 +68,7 @@ static inline void irqc_send_ipi(cpuid_t target_cpu, irqid_t ipi_id)
 {
 #if (IRQC == APLIC)
     UNUSED_ARG(ipi_id);
-    sbi_send_ipi(1ULL << target_cpu, 0);
+    sbi_send_ipi(1UL << target_cpu, 0);
 #elif (IRQC == AIA)
     imsic_send_msi(target_cpu, ipi_id);
 #endif

--- a/src/arch/riscv/irqc/plic/inc/irqc.h
+++ b/src/arch/riscv/irqc/plic/inc/irqc.h
@@ -34,7 +34,7 @@ static inline irqid_t irqc_reserve(irqid_t pintp_id)
 static inline void irqc_send_ipi(cpuid_t target_cpu, irqid_t ipi_id)
 {
     UNUSED_ARG(ipi_id);
-    sbi_send_ipi(1ULL << target_cpu, 0);
+    sbi_send_ipi(1UL << target_cpu, 0);
 }
 
 static inline void irqc_cpu_init(void)


### PR DESCRIPTION
Compilation is failing for rv32. I guess we need to add this variant to CI.