### PR TITLE
fix(armv8/aarch32): restore/save extra lr on vm entry/exit

### DIFF
--- a/src/arch/armv8/aarch32/exceptions.S
+++ b/src/arch/armv8/aarch32/exceptions.S
@@ -46,14 +46,14 @@
 .macro VM_EXIT
 
     push {r14}
-    SAVE_SP
+    SAVE_LR_SP
     push {r0-r12}
     SAVE_ELR_SPSR
 
 .endm
 
 
-.macro SAVE_SP
+.macro SAVE_LR_SP
 
     mrs r14, SPSR_hyp
     and r14, r14, #0x1F
@@ -70,29 +70,39 @@
     beq 5f
     
     1:  //read_usr:
+        mrs r14,  lr_usr
+        push {r14}
         mrs r14,  sp_usr
         push {r14}
         b 6f
     2:  //read_irq:
+        mrs r14,  lr_irq
+        push {r14}
         mrs r14,  sp_irq
         push {r14}
         b 6f
     3:  //read_hvc:
+        mrs r14,  lr_svc
+        push {r14}
         mrs r14,  sp_svc
         push {r14}
         b 6f
     4:  //read_abt:
+        mrs r14,  lr_abt
+        push {r14}
         mrs r14,  sp_abt
         push {r14}
         b 6f
     5:  //read_und:
+        mrs r14,  lr_und
+        push {r14}
         mrs r14,  sp_und
         push {r14}
     6:
 
 .endm
 
-.macro LOAD_SP
+.macro LOAD_SP_LR
 
     mrs r14, SPSR_hyp
     and r14, r14, #0x1F
@@ -111,22 +121,32 @@
     1:  
         pop {r14}
         msr sp_usr, r14
+        pop {r14}
+        msr lr_usr, r14
         b 6f
     2:
         pop {r14}
         msr sp_irq, r14
+        pop {r14}
+        msr lr_irq, r14
         b 6f
     3:
         pop {r14}
         msr sp_svc, r14
+        pop {r14}
+        msr lr_svc, r14
         b 6f
     4:
         pop {r14}
         msr sp_abt, r14
+        pop {r14}
+        msr lr_abt, r14
         b 6f
     5:
         pop {r14}
         msr sp_und, r14
+        pop {r14}
+        msr lr_und, r14
     6:
 
 .endm
@@ -140,7 +160,7 @@
 
     LOAD_ELR_SPSR
     pop {r0-r12}
-    LOAD_SP
+    LOAD_SP_LR
     pop {r14}
     
     eret

--- a/src/arch/armv8/aarch32/inc/arch/subarch/vm.h
+++ b/src/arch/armv8/aarch32/inc/arch/subarch/vm.h
@@ -12,6 +12,7 @@ struct arch_regs {
     uint32_t elr_hyp;
     uint32_t spsr_hyp;
     uint32_t x[15];
+    uint32_t lr_usr;
 };
 
 #endif /* VM_SUBARCH_H */


### PR DESCRIPTION
Hyp mod uses lr from user mode. This means we were only saving/restoring the lr from this mode. But in addition to this lr we need to restore the lr of the mode we just preemted (e.g., lr_irq) so that we can inspect and manipulate the state of the mode that was trapped.