### PR TITLE
Add missing spinlock initializations

### DIFF
--- a/src/arch/armv8/aarch32/inc/arch/spinlock.h
+++ b/src/arch/armv8/aarch32/inc/arch/spinlock.h
@@ -15,12 +15,6 @@ typedef struct {
 
 static const spinlock_t SPINLOCK_INITVAL = { 0, 0 };
 
-static inline void spinlock_init(spinlock_t* lock)
-{
-    lock->ticket = 0;
-    lock->next = 0;
-}
-
 /**
  * This lock follows the ticket lock algorithm described in Arm's ARM DDI0487I.a
  * Appendix K13.

--- a/src/arch/armv8/aarch64/inc/arch/spinlock.h
+++ b/src/arch/armv8/aarch64/inc/arch/spinlock.h
@@ -15,12 +15,6 @@ typedef struct {
 
 static const spinlock_t SPINLOCK_INITVAL = { 0, 0 };
 
-static inline void spinlock_init(spinlock_t* lock)
-{
-    lock->ticket = 0;
-    lock->next = 0;
-}
-
 /**
  * This lock follows the ticket lock algorithm described in Arm's ARM DDI0487I.a Appendix K13.
  */

--- a/src/arch/armv8/vgicv2.c
+++ b/src/arch/armv8/vgicv2.c
@@ -148,6 +148,7 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
     vm->arch.vgicd.TYPER = ((vtyper_itln << GICD_TYPER_ITLN_OFF) & GICD_TYPER_ITLN_MSK) |
         (((vm->cpu_num - 1) << GICD_TYPER_CPUNUM_OFF) & GICD_TYPER_CPUNUM_MSK);
     vm->arch.vgicd.IIDR = gicd->IIDR;
+    vm->arch.vgicd.lock = SPINLOCK_INITVAL;
 
     size_t n = NUM_PAGES(sizeof(struct gicc_hw));
     mem_alloc_map_dev(&vm->as, SEC_VM_ANY, (vaddr_t)vgic_dscrp->gicc_addr,

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -328,6 +328,7 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
         (((vm->cpu_num - 1) << GICD_TYPER_CPUNUM_OFF) & GICD_TYPER_CPUNUM_MSK) |
         (((10 - 1) << GICD_TYPER_IDBITS_OFF) & GICD_TYPER_IDBITS_MSK);
     vm->arch.vgicd.IIDR = gicd->IIDR;
+    vm->arch.vgicd.lock = SPINLOCK_INITVAL;
 
     size_t vgic_int_size = vm->arch.vgicd.int_num * sizeof(struct vgic_int);
     vm->arch.vgicd.interrupts = mem_alloc_page(NUM_PAGES(vgic_int_size), SEC_HYP_VM, false);
@@ -362,6 +363,7 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
         vcpu->arch.vgic_priv.vgicr.TYPER = typer;
 
         vcpu->arch.vgic_priv.vgicr.IIDR = gicr[cpu()->id].IIDR;
+        vcpu->arch.vgic_priv.vgicr.lock = SPINLOCK_INITVAL;
     }
 
     vm->arch.vgicr_emul = (struct emul_mem){ .va_base = vgic_dscrp->gicr_addr,

--- a/src/arch/armv8/vm.c
+++ b/src/arch/armv8/vm.c
@@ -51,6 +51,7 @@ void vcpu_arch_init(struct vcpu* vcpu, struct vm* vm)
     sysreg_vmpidr_el2_write(vcpu->arch.vmpidr);
 
     vcpu->arch.psci_ctx.state = vcpu->id == 0 ? ON : OFF;
+    vcpu->arch.psci_ctx.lock = SPINLOCK_INITVAL;
 
     vcpu_arch_profile_init(vcpu, vm);
 

--- a/src/arch/riscv/inc/arch/spinlock.h
+++ b/src/arch/riscv/inc/arch/spinlock.h
@@ -15,12 +15,6 @@ typedef struct {
 
 static const spinlock_t SPINLOCK_INITVAL = { 0, 0 };
 
-static inline void spinlock_init(spinlock_t* lock)
-{
-    lock->ticket = 0;
-    lock->next = 0;
-}
-
 static inline void spin_lock(spinlock_t* lock)
 {
     uint32_t const INCR = 1;

--- a/src/arch/riscv/irqc/aia/vaplic.c
+++ b/src/arch/riscv/irqc/aia/vaplic.c
@@ -1373,6 +1373,7 @@ void vaplic_init(struct vm* vm, const union vm_irqc_dscrp* vm_irqc_dscrp)
     if (cpu()->id == vm->master) {
         /* 1 IDC per hart */
         vm->arch.vaplic.idc_num = vm->cpu_num;
+        vm->arch.vaplic.lock = SPINLOCK_INITVAL;
 
         vm->arch.vaplic.aplic_domain_emul =
             (struct emul_mem){ .va_base = vm_irqc_dscrp->aia.aplic.base,

--- a/src/arch/riscv/irqc/plic/vplic.c
+++ b/src/arch/riscv/irqc/plic/vplic.c
@@ -387,5 +387,6 @@ void vplic_init(struct vm* vm, const union vm_irqc_dscrp* vm_irqc_dscrp)
 
         /* assumes 2 contexts per hart */
         vm->arch.vplic.cntxt_num = vm->cpu_num * 2;
+        vm->arch.vplic.lock = SPINLOCK_INITVAL;
     }
 }

--- a/src/core/mem.c
+++ b/src/core/mem.c
@@ -229,6 +229,7 @@ static void pp_init(struct page_pool* pool, paddr_t base, size_t size)
 
     pool->last = 0;
     pool->free = pool->size;
+    pool->lock = SPINLOCK_INITVAL;
 }
 
 static bool mem_vm_img_in_phys_rgn(struct vm_config* vm_config)

--- a/src/core/mpu/mem.c
+++ b/src/core/mpu/mem.c
@@ -195,6 +195,7 @@ void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, colormap_t col
     as->type = type;
     as->colors = 0;
     as->id = id;
+    as->lock = SPINLOCK_INITVAL;
     as_arch_init(as);
 
     for (size_t i = 0; i < VMPU_NUM_ENTRIES; i++) {

--- a/src/core/objpool.c
+++ b/src/core/objpool.c
@@ -10,6 +10,7 @@ void objpool_init(struct objpool* objpool)
 {
     memset(objpool->pool, 0, objpool->objsize * objpool->num);
     memset(objpool->bitmap, 0, BITMAP_SIZE(objpool->num));
+    objpool->lock = SPINLOCK_INITVAL;
 }
 
 void* objpool_alloc_with_id(struct objpool* objpool, objpool_id_t* id)

--- a/src/core/shmem.c
+++ b/src/core/shmem.c
@@ -13,6 +13,7 @@ static void shmem_alloc(void)
 {
     for (size_t i = 0; i < shmem_table_size; i++) {
         struct shmem* shmem = &shmem_table[i];
+        shmem->lock = SPINLOCK_INITVAL;
         if (!shmem->place_phys) {
             size_t n_pg = NUM_PAGES(shmem->size);
             struct ppages ppages = mem_alloc_ppages(shmem->colors, n_pg, false);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -17,6 +17,7 @@ static void vm_master_init(struct vm* vm, const struct vm_config* vm_config, vmi
     vm->config = vm_config;
     vm->cpu_num = vm_config->platform.cpu_num;
     vm->id = vm_id;
+    vm->lock = SPINLOCK_INITVAL;
 
     cpu_sync_init(&vm->sync, vm->cpu_num);
 

--- a/src/core/vmm.c
+++ b/src/core/vmm.c
@@ -29,6 +29,7 @@ static bool vmm_assign_vcpu(bool* master, vmid_t* vm_id)
     /* Assign cpus according to vm affinity. */
     for (size_t i = 0; i < config.vmlist_size && !assigned; i++) {
         if (config.vmlist[i].cpu_affinity & (1UL << cpu()->id)) {
+            vm_assign[i].lock = SPINLOCK_INITVAL;
             spin_lock(&vm_assign[i].lock);
             if (!vm_assign[i].master) {
                 vm_assign[i].master = true;


### PR DESCRIPTION
This PR adds missing initialization of spinlocks across the source code.
Uninitialized control structures are a potential cause of random behavior issues.

The PR also deletes the unused `spinlock_init` function, as spinlock initialization in Bao is done via the `SPINLOCK_INITVAL` macro.