### PR TITLE
fix(armv8): return from cache probing if topology described in the plat

### DIFF
--- a/src/arch/armv8/cache.c
+++ b/src/arch/armv8/cache.c
@@ -14,9 +14,11 @@ void cache_arch_enumerate(struct cache* dscrp)
     if (platform.cache.lvls != 0) {
         /**
          * No need to probe cache registers, cache topology is described in the platform
-         * descrption.
+         * description.
          */
         *dscrp = platform.cache;
+
+        return;
     }
 
     uint64_t clidr = 0;


### PR DESCRIPTION
Add missing return to cache arch enumerate if cache topology is described in the platform description. 