### PR TITLE
feat/static-bitmaps: change bitmaps to be statically allocated

### DIFF
--- a/scripts/platform_defs_gen.c
+++ b/scripts/platform_defs_gen.c
@@ -24,7 +24,7 @@ int main() {
 
         reg_size = platform.regions[i].size;
 
-        bitmap_array_size += reg_size / (8 * PAGE_SIZE) + ((reg_size % (8 * PAGE_SIZE) != 0) ? 1 : 0);
+        bitmap_array_size += BITMAP_SIZE_IN_BYTES(NUM_PAGES(reg_size));
     }
 
     printf("#define PLAT_BITMAP_POOL_SIZE (0x%lx)\n", bitmap_array_size);

--- a/scripts/platform_defs_gen.c
+++ b/scripts/platform_defs_gen.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <platform.h>
+#include <bao.h>
 
 __attribute__((weak)) void arch_platform_defs(void){
     return;
@@ -12,8 +13,22 @@ __attribute__((weak)) void arch_platform_defs(void){
 
 int main() {
 
+    size_t bitmap_array_size = 0;
+
     printf("#define PLAT_CPU_NUM (%ld)\n", platform.cpu_num);
     printf("#define PLAT_BASE_ADDR (0x%lx)\n", platform.regions[0].base);
+
+    for(size_t i = 0; i < platform.region_num; i++)
+    {
+        size_t reg_size;
+
+        reg_size = platform.regions[i].size;
+
+        bitmap_array_size += reg_size / (8 * PAGE_SIZE) + ((reg_size % (8 * PAGE_SIZE) != 0) ? 1 : 0);
+    }
+
+    printf("#define PLAT_BITMAP_POOL_SIZE (0x%lx)\n", bitmap_array_size);
+
     if (platform.cpu_master_fixed) {
         printf("#define CPU_MASTER_FIXED (%ld)\n", platform.cpu_master);
     }

--- a/src/core/objpool.c
+++ b/src/core/objpool.c
@@ -9,7 +9,7 @@
 void objpool_init(struct objpool* objpool)
 {
     memset(objpool->pool, 0, objpool->objsize * objpool->num);
-    memset(objpool->bitmap, 0, BITMAP_SIZE(objpool->num));
+    memset(objpool->bitmap, 0, BITMAP_SIZE_IN_BYTES(objpool->num));
     objpool->lock = SPINLOCK_INITVAL;
 }
 

--- a/src/lib/inc/bitmap.h
+++ b/src/lib/inc/bitmap.h
@@ -16,14 +16,16 @@ typedef bitmap_granule_t bitmap_t;
 
 static const bitmap_granule_t ONE = 1;
 
-#define BITMAP_GRANULE_LEN                  (sizeof(bitmap_granule_t) * 8)
-#define BITMAP_GRANULE_MASK(O, L)           BIT32_MASK((O), (L))
+#define BITMAP_GRANULE_LEN        (sizeof(bitmap_granule_t) * 8)
+#define BITMAP_GRANULE_MASK(O, L) BIT32_MASK((O), (L))
 
-#define BITMAP_SIZE(SIZE)                   (((SIZE) / BITMAP_GRANULE_LEN) + ((SIZE) % BITMAP_GRANULE_LEN ? 1 : 0))
-#define BITMAP_SIZE_IN_BYTES(NUM_BITS)      (((NUM_BITS) / 8) + (((NUM_BITS) % 8) > 0 ? 1 : 0))
-#define BITMAP_ALLOC(NAME, SIZE)            bitmap_granule_t NAME[BITMAP_SIZE(SIZE)]
+#define BITMAP_SIZE(NUM_BITS, BITS_PER_UNIT) \
+    (((NUM_BITS) / (BITS_PER_UNIT)) + (((NUM_BITS) % (BITS_PER_UNIT)) ? 1 : 0))
+#define BITMAP_SIZE_IN_GRANULE(NUM_BITS)    (BITMAP_SIZE((NUM_BITS), (BITMAP_GRANULE_LEN)))
+#define BITMAP_SIZE_IN_BYTES(NUM_BITS)      (BITMAP_SIZE((NUM_BITS), 8))
+#define BITMAP_ALLOC(NAME, SIZE)            bitmap_granule_t NAME[BITMAP_SIZE_IN_GRANULE(SIZE)]
 
-#define BITMAP_ALLOC_ARRAY(NAME, SIZE, NUM) bitmap_granule_t NAME[NUM][BITMAP_SIZE(SIZE)]
+#define BITMAP_ALLOC_ARRAY(NAME, SIZE, NUM) bitmap_granule_t NAME[NUM][BITMAP_SIZE_IN_GRANULE(SIZE)]
 
 static inline void bitmap_set(bitmap_t* map, size_t bit)
 {

--- a/src/lib/inc/bitmap.h
+++ b/src/lib/inc/bitmap.h
@@ -20,7 +20,7 @@ static const bitmap_granule_t ONE = 1;
 #define BITMAP_GRANULE_MASK(O, L)           BIT32_MASK((O), (L))
 
 #define BITMAP_SIZE(SIZE)                   (((SIZE) / BITMAP_GRANULE_LEN) + ((SIZE) % BITMAP_GRANULE_LEN ? 1 : 0))
-
+#define BITMAP_SIZE_IN_BYTES(NUM_BITS)      (((NUM_BITS) / 8) + (((NUM_BITS) % 8) > 0 ? 1 : 0))
 #define BITMAP_ALLOC(NAME, SIZE)            bitmap_granule_t NAME[BITMAP_SIZE(SIZE)]
 
 #define BITMAP_ALLOC_ARRAY(NAME, SIZE, NUM) bitmap_granule_t NAME[NUM][BITMAP_SIZE(SIZE)]


### PR DESCRIPTION
This pull request refactors the memory bitmap allocation logic to use a preallocated bitmap pool. We introduce a global bitmap pool and update relevant functions to allocate bitmaps from this pool instead of allocating memory dynamically. With this PR we optimize the use of MPU regions in MMU-less platforms, as the global bitmap is allocated in the .bss section as part of the hyp image.
To calculate the size of the global bitmap pool based on platform regions, we added `PLAT_BITMAP_POOL_SIZE` in `scripts/platform_defs_gen.c`.