### PR TITLE
fix(mem): fix root pool bitmap size

### DIFF
--- a/src/core/inc/mem.h
+++ b/src/core/inc/mem.h
@@ -24,7 +24,7 @@ struct ppages {
 struct page_pool {
     node_t node;
     paddr_t base;
-    size_t size;
+    size_t num_pages;
     size_t free;
     size_t last;
     bitmap_t* bitmap;

--- a/src/core/mmu/mem.c
+++ b/src/core/mmu/mem.c
@@ -78,7 +78,7 @@ static void mem_free_ppages(struct ppages* ppages)
 {
     list_foreach (page_pool_list, struct page_pool, pool) {
         spin_lock(&pool->lock);
-        if (in_range(ppages->base, pool->base, pool->size * PAGE_SIZE)) {
+        if (in_range(ppages->base, pool->base, pool->num_pages * PAGE_SIZE)) {
             size_t index = (ppages->base - pool->base) / PAGE_SIZE;
             if (!all_clrs(ppages->colors)) {
                 for (size_t i = 0; i < ppages->num_pages; i++) {
@@ -110,7 +110,7 @@ bool pp_alloc_clr(struct page_pool* pool, size_t n, colormap_t colors, struct pp
      * top of the pool.
      */
     size_t index = pp_next_clr(pool->base, pool->last, colors);
-    size_t top = pool->size;
+    size_t top = pool->num_pages;
 
     /**
      * Two iterations. One starting from the last known free page, other starting from the
@@ -748,7 +748,7 @@ void mem_color_hypervisor(const paddr_t load_addr, struct mem_region* root_regio
     size_t cpu_boot_size = mem_cpu_boot_alloc_size();
     struct page_pool* root_pool = &root_region->page_pool;
     size_t bitmap_size =
-        (root_pool->size / (8 * PAGE_SIZE) + !!(root_pool->size % (8 * PAGE_SIZE) != 0)) *
+        (root_pool->num_pages / (8 * PAGE_SIZE) + !!(root_pool->num_pages % (8 * PAGE_SIZE) != 0)) *
         PAGE_SIZE;
     colormap_t colors = config.hyp.colors;
 

--- a/src/core/mpu/mem.c
+++ b/src/core/mpu/mem.c
@@ -222,7 +222,7 @@ static void mem_free_ppages(struct ppages* ppages)
 {
     list_foreach (page_pool_list, struct page_pool, pool) {
         spin_lock(&pool->lock);
-        if (in_range(ppages->base, pool->base, pool->size * PAGE_SIZE)) {
+        if (in_range(ppages->base, pool->base, pool->num_pages * PAGE_SIZE)) {
             size_t index = (ppages->base - pool->base) / PAGE_SIZE;
             bitmap_clear_consecutive(pool->bitmap, index, ppages->num_pages);
         }


### PR DESCRIPTION
This PR fixes the calculation of the root pool's bitmap size.

The expression `root_pool->size` in the `root_pool_set_up_bitmap` function was being mistakenly interpreted as the size of the root pool in **bytes**, when it is actually the size of the root pool in **number of pages**.

To avoid further misunderstandings, this PR also changes the name of the `struct page_pool.size` field to `num_pages` 