### PR TITLE
feat(plat): add platform initialization functions

### DIFF
--- a/src/core/inc/platform.h
+++ b/src/core/inc/platform.h
@@ -32,4 +32,8 @@ struct platform {
 
 extern struct platform platform;
 
+void platform_init(void);
+void platform_default_init(void);
+void platform_config_init(void);
+
 #endif /* __PLATFORM_H__ */

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -24,6 +24,8 @@ void init(cpuid_t cpu_id, paddr_t load_addr)
 
     /* -------------------------------------------------------------- */
 
+    platform_init();
+
     console_init();
 
     if (cpu_is_master()) {

--- a/src/core/objects.mk
+++ b/src/core/objects.mk
@@ -15,3 +15,4 @@ core-objs-y+=objpool.o
 core-objs-y+=hypercall.o
 core-objs-y+=shmem.o
 core-objs-y+=remio.o
+core-objs-y+=platform.o

--- a/src/core/platform.c
+++ b/src/core/platform.c
@@ -1,0 +1,16 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <platform.h>
+
+__attribute__((weak)) void platform_default_init(void) { }
+
+__attribute__((weak)) void platform_config_init(void) { }
+
+void platform_init(void)
+{
+    platform_default_init();
+    platform_config_init();
+}


### PR DESCRIPTION
This PR introduces two new platform initialization functions to support platforms lacking firmware-provided initialization.

- platform_default_init: performs the minimal setup required for Bao to run (e.g., UART pinout).
- platform_config_init: allows users to extend the initialization with additional platform-specific configuration.

In addition, we added a generic MMIO helper header to provide a uniform and straightforward way of accessing platform configuration registers.