### PR TITLE
fix(mpu): add inst sync barrier to mpu enable

### DIFF
--- a/src/arch/armv8/armv8-r/aarch32/boot.S
+++ b/src/arch/armv8/armv8-r/aarch32/boot.S
@@ -50,7 +50,7 @@ boot_arch_profile_init:
     /* r4 contains the id of the MPU entry being used */
     mov r4, #(-1)
 
-    /* Enable caches and MPU */
+    /* Enable caches */
     ldr r4, =(SCTLR_RES1_AARCH32 | SCTLR_C | SCTLR_I)
     mcr p15, 4, r4, c1, c0, 0 // HSCTLR
 

--- a/src/arch/armv8/armv8-r/mpu.c
+++ b/src/arch/armv8/armv8-r/mpu.c
@@ -199,7 +199,13 @@ bool mpu_perms_compatible(unsigned long perms1, unsigned long perms2)
 
 void mpu_enable(void)
 {
-    sysreg_sctlr_el2_write(SCTLR_M);
+    unsigned long reg_val;
+
+    reg_val = sysreg_sctlr_el2_read();
+    reg_val |= SCTLR_M;
+    sysreg_sctlr_el2_write(reg_val);
+
+    ISB();
 }
 
 void mpu_init()


### PR DESCRIPTION
This PR fixes the missing of an instruction synchronization barrier after enabling the MPU in ARMv8-R architectures. This is mandatory to any change to system registers as mentioned in the architectural reference manual. 

> An ISB instruction ensures that all instructions that come after the ISB instruction in program order are fetched from the
cache or memory after the ISB instruction has completed. Using an ISB ensures that the effects of context-changing
operations executed before the ISB are visible to the instructions fetched after the ISB instruction. Examples of
context-changing operations that require the insertion of an ISB instruction to ensure the effects of the operation are
visible to instructions fetched after the ISB instruction are:
•Completed cache and TLB maintenance instructions.
•Changes to System registers.