### PR TITLE
feat(phys-irqs): add support to physical interrupts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,9 @@ endif
 ifeq ($(plat_mem),non_unified)
 	build_macros+=-DMEM_NON_UNIFIED
 endif
+ifeq ($(phys_irqs_only),y)
+	build_macros+=-DPHYS_IRQS_ONLY
+endif
 
 ifeq ($(CC_IS_GCC),y)
 	build_macros+=-DCC_IS_GCC

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -182,6 +182,14 @@ static void vm_init_ipc(struct vm* vm, const struct vm_config* vm_config)
             WARNING("Trying to map region to smaller shared memory. Truncated");
         }
 
+        if (DEFINED(PHYS_IRQS_ONLY)) {
+            for (size_t j = 0; j < ipc->interrupt_num; j++) {
+                if (!interrupts_vm_assign(vm, ipc->interrupts[j])) {
+                    ERROR("Failed to assign interrupt id %d", ipc->interrupts[j]);
+                }
+            }
+        }
+
         spin_lock(&shmem->lock);
         shmem->cpu_masters |= (1UL << cpu()->id);
         spin_unlock(&shmem->lock);


### PR DESCRIPTION
## PR Description

This PR introduces support for physical IRQs. 
Architectures that use hardware IRQs need to have the IPC interrupts assigned to the correct VM, which wasn't being done.

This PR was tested on TC4 that uses hw irqs. 
