### PR TITLE
fix(mem): fetch img_addr variable address correctly in asm

### DIFF
--- a/src/arch/armv8/aarch32/boot.S
+++ b/src/arch/armv8/aarch32/boot.S
@@ -54,7 +54,7 @@ _reset_handler:
      * Get base image load address.
      */
     adr r1, _el2_entry
-    ldr r3, =img_addr
+    get_phys_addr r3, r4, img_addr
     str r1, [r3] // store image load address in img_addr
 
     /**

--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -48,7 +48,7 @@ _reset_handler:
 	mrs  x0, MPIDR_EL1
 	adrp x1, _image_start
 
-	ldr x2, =img_addr
+	adr x2, img_addr
     str x1, [x2] // store image load address in img_addr
 
 	/*

--- a/src/arch/riscv/boot.S
+++ b/src/arch/riscv/boot.S
@@ -98,7 +98,7 @@ _reset_handler:
     mv      a2, a1
     la      a1, _image_start
 
-    LD_SYM  a3, img_addr
+    la      a3, img_addr
     STORE   a1, 0(a3) // store image load address in img_addr
 
     LD_SYM  s6, _extra_allocated_phys_mem_sym


### PR DESCRIPTION
Commit 1c292112 didn't take into account the fact that for MMU systems, the `img_addr` has a different physical address at the time it is set (before enabling the MMU) than the virtual address used at runtime (with the MMU enabled)