### PR TITLE
ref(as): remove unused variable from addr_space struct

### DIFF
--- a/src/core/mpu/inc/mem_prot/mem.h
+++ b/src/core/mpu/inc/mem_prot/mem.h
@@ -25,7 +25,6 @@ struct mp_region {
 struct addr_space {
     asid_t id;
     enum AS_TYPE type;
-    cpumap_t cpus;
     colormap_t colors;
     struct addr_space_arch arch;
     struct {
@@ -41,7 +40,7 @@ struct addr_space {
     spinlock_t lock;
 };
 
-void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, cpumap_t cpus, colormap_t colors);
+void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, colormap_t colors);
 
 static inline bool mem_regions_overlap(struct mp_region* reg1, struct mp_region* reg2)
 {

--- a/src/core/mpu/mem.c
+++ b/src/core/mpu/mem.c
@@ -203,7 +203,7 @@ static void mem_init_boot_regions(void)
 void mem_prot_init()
 {
     mpu_init();
-    as_init(&cpu()->as, AS_HYP, HYP_ASID, BIT_MASK(0, PLAT_CPU_NUM), 0);
+    as_init(&cpu()->as, AS_HYP, HYP_ASID, 0);
     mem_init_boot_regions();
     mpu_enable();
 }
@@ -214,14 +214,13 @@ size_t mem_cpu_boot_alloc_size()
     return size;
 }
 
-void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, cpumap_t cpus, colormap_t colors)
+void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, colormap_t colors)
 {
     UNUSED_ARG(colors);
 
     as->type = type;
     as->colors = 0;
     as->id = id;
-    as->cpus = cpus;
     as->lock = SPINLOCK_INITVAL;
     as_arch_init(as);
 

--- a/src/core/mpu/vm.c
+++ b/src/core/mpu/vm.c
@@ -9,5 +9,5 @@ void vm_mem_prot_init(struct vm* vm, const struct vm_config* config)
 {
     UNUSED_ARG(config);
 
-    as_init(&vm->as, AS_VM, vm->id, vm->cpus, 0);
+    as_init(&vm->as, AS_VM, vm->id, 0);
 }

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -28,7 +28,6 @@ static void vm_cpu_init(struct vm* vm)
 {
     spin_lock(&vm->lock);
     vm->cpus |= (1UL << cpu()->id);
-    vm->as.cpus |= (1UL << cpu()->id);
     spin_unlock(&vm->lock);
 }
 


### PR DESCRIPTION
## PR Description

This PR removes an unused variable from the addr_space struct. The cpu variable was being set, but never used.
This might be needed because a later PR will need a slight modification on the vm_init function where the order of function will be re-arranged. 
However, there are 2 problems that I could identify with this change:

- In function `mem_section_shared_cpus` in core/mpu/mem.c (252) the following code could/should be changed from:
```
else {
        cpus = cpu()->vcpu->vm->cpus;
    }
```

to 

```
else {
        cpus = as->cpus;
    }
```
- And the prototype of `as_init` becomes different from MPU platforms (4 parameters) to MMU platforms (5 parameters)

I would like to get some opinions regarding this topic. @josecm @DavidMCerdeira @danielRep 