### PR TITLE
feat(unique-asid): Make address spaces IDs unique

### DIFF
--- a/src/core/mmu/inc/mem_prot/mem.h
+++ b/src/core/mmu/inc/mem_prot/mem.h
@@ -21,7 +21,7 @@ struct addr_space {
 
 typedef pte_t mem_flags_t;
 
-void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, pte_t* root_pt, colormap_t colors);
+void as_init(struct addr_space* as, enum AS_TYPE type, pte_t* root_pt, colormap_t colors);
 vaddr_t mem_alloc_vpage(struct addr_space* as, enum AS_SEC section, vaddr_t at, size_t n);
 
 #endif /* __MEM_PROT_H__ */

--- a/src/core/mmu/mem.c
+++ b/src/core/mmu/mem.c
@@ -764,7 +764,7 @@ void mem_color_hypervisor(const paddr_t load_addr, struct mem_region* root_regio
      * the new CPU region is created, cleaned, prepared and finally mapped.
      */
     cpu_new = copy_space((void*)BAO_CPU_BASE, sizeof(struct cpu), &p_cpu);
-    as_init(&cpu_new->as, AS_HYP_CPY, HYP_ASID, NULL, colors);
+    as_init(&cpu_new->as, AS_HYP_CPY, NULL, colors);
     va = mem_alloc_vpage(&cpu_new->as, SEC_HYP_PRIVATE, (vaddr_t)BAO_CPU_BASE,
         NUM_PAGES(sizeof(struct cpu)));
     if (va != (vaddr_t)BAO_CPU_BASE) {
@@ -860,7 +860,7 @@ void mem_color_hypervisor(const paddr_t load_addr, struct mem_region* root_regio
         while (shared_pte != 0) { }
     }
 
-    as_init(&cpu()->as, AS_HYP, HYP_ASID, (void*)v_root_pt_addr, colors);
+    as_init(&cpu()->as, AS_HYP, (void*)v_root_pt_addr, colors);
 
     /*
      * Clear the old region that have been copied.
@@ -916,10 +916,8 @@ static unsigned long as_id_alloc(struct addr_space* as)
     return ret;
 }
 
-void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, pte_t* root_pt, colormap_t colors)
+void as_init(struct addr_space* as, enum AS_TYPE type, pte_t* root_pt, colormap_t colors)
 {
-    UNUSED_ARG(id);
-
     as->type = type;
     as->pt.dscr = type == AS_HYP || type == AS_HYP_CPY ? hyp_pt_dscr : vm_pt_dscr;
     as->id = as_id_alloc(as);
@@ -940,7 +938,7 @@ void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, pte_t* root_pt
 void mem_prot_init(void)
 {
     pte_t* root_pt = (pte_t*)ALIGN(((vaddr_t)cpu()) + sizeof(struct cpu), PAGE_SIZE);
-    as_init(&cpu()->as, AS_HYP, HYP_ASID, root_pt, config.hyp.colors);
+    as_init(&cpu()->as, AS_HYP, root_pt, config.hyp.colors);
 }
 
 vaddr_t mem_alloc_map(struct addr_space* as, enum AS_SEC section, struct ppages* page, vaddr_t at,

--- a/src/core/mmu/vm.c
+++ b/src/core/mmu/vm.c
@@ -10,5 +10,5 @@
 
 void vm_mem_prot_init(struct vm* vm, const struct vm_config* vm_config)
 {
-    as_init(&vm->as, AS_VM, vm->id, NULL, vm_config->colors);
+    as_init(&vm->as, AS_VM, NULL, vm_config->colors);
 }

--- a/src/core/mpu/inc/mem_prot/mem.h
+++ b/src/core/mpu/inc/mem_prot/mem.h
@@ -38,7 +38,7 @@ struct addr_space {
     spinlock_t lock;
 };
 
-void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, colormap_t colors);
+void as_init(struct addr_space* as, enum AS_TYPE type, colormap_t colors);
 
 static inline bool mem_regions_overlap(struct mp_region* reg1, struct mp_region* reg2)
 {

--- a/src/core/mpu/mem.c
+++ b/src/core/mpu/mem.c
@@ -203,7 +203,7 @@ static void mem_init_boot_regions(void)
 void mem_prot_init()
 {
     mpu_init();
-    as_init(&cpu()->as, AS_HYP, HYP_ASID, 0);
+    as_init(&cpu()->as, AS_HYP, 0);
     mem_init_boot_regions();
     mpu_enable();
 }
@@ -239,10 +239,9 @@ static unsigned long as_id_alloc(struct addr_space* as)
     return ret;
 }
 
-void as_init(struct addr_space* as, enum AS_TYPE type, asid_t id, colormap_t colors)
+void as_init(struct addr_space* as, enum AS_TYPE type, colormap_t colors)
 {
     UNUSED_ARG(colors);
-    UNUSED_ARG(id);
 
     as->type = type;
     as->colors = 0;

--- a/src/core/mpu/vm.c
+++ b/src/core/mpu/vm.c
@@ -9,5 +9,5 @@ void vm_mem_prot_init(struct vm* vm, const struct vm_config* config)
 {
     UNUSED_ARG(config);
 
-    as_init(&vm->as, AS_VM, vm->id, 0);
+    as_init(&vm->as, AS_VM, 0);
 }


### PR DESCRIPTION
## PR Description

This PR makes the IDs fo address spaces unique. The only exception is the hypervisor address space that always has ID = 0.
This change is needed because the MPU driver only has access to the address space, and not vm/hypervisor structs. Some platforms like TC4, use the as->id to distinguish between vms. Prior to this change, the first VM (vm->id = 0) would have it's address space ID equal to 0, which would collide with the hypervisor address space ID.

This PR still has to be tested on all platforms. It compiles, but hasn't been tested.