### PR TITLE
fix(armv8): fix aarch32 hcr init

### DIFF
--- a/src/arch/armv8/vmm.c
+++ b/src/arch/armv8/vmm.c
@@ -11,8 +11,11 @@ void vmm_arch_init()
 {
     vmm_arch_profile_init();
 
-    uint64_t hcr = HCR_VM_BIT | HCR_RW_BIT | HCR_IMO_BIT | HCR_FMO_BIT | HCR_TSC_BIT | HCR_APK_BIT |
-        HCR_API_BIT;
+    uint64_t hcr = HCR_VM_BIT | HCR_IMO_BIT | HCR_FMO_BIT | HCR_TSC_BIT;
+
+    if (DEFINED(AARCH64)) {
+        hcr |= HCR_RW_BIT | HCR_APK_BIT | HCR_API_BIT;
+    }
 
     sysreg_hcr_el2_write(hcr);
 


### PR DESCRIPTION
Certain bits are res0 for aarch32 hcr system registers. Thefore we can only set these bits for aarch64.