### PR TITLE
feat(armv8r): handle different timer init cases

### DIFF
--- a/src/arch/armv8/armv8-r/vmm.c
+++ b/src/arch/armv8/armv8-r/vmm.c
@@ -15,24 +15,35 @@ static uint32_t timer_freq = 0;
 void vmm_arch_profile_init()
 {
     if (cpu_is_master()) {
-        /**
-         * Since there is no firmware in cortex-r platforms, we need to initialize the system
-         * counter.
-         */
-        volatile struct generic_timer_cntctrl* timer_ctl;
-        timer_ctl = (struct generic_timer_cntctrl*)mem_alloc_map_dev(&cpu()->as, SEC_HYP_PRIVATE,
-            platform.arch.generic_timer.base_addr, platform.arch.generic_timer.base_addr,
-            sizeof(struct generic_timer_cntctrl));
+        unsigned long cur_cntfrq = sysreg_cntfrq_el0_read();
+        if (cur_cntfrq != 0UL) {
+            timer_freq = (uint32_t)cur_cntfrq;
+        } else if (platform.arch.generic_timer.fixed_freq != 0) {
+            timer_freq = (uint32_t)platform.arch.generic_timer.fixed_freq;
+        } else {
+            if (platform.arch.generic_timer.base_addr == 0) {
+                ERROR("generic timer base_addr undefined; cannot init system counter");
+            }
 
-        timer_ctl->CNTCR |= GENERIC_TIMER_CNTCTL_CNTCR_EN;
-        fence_ord_write();
+            volatile struct generic_timer_cntctrl* timer_ctl;
+            timer_ctl = (struct generic_timer_cntctrl*)mem_alloc_map_dev(&cpu()->as,
+                SEC_HYP_PRIVATE, platform.arch.generic_timer.base_addr,
+                platform.arch.generic_timer.base_addr, sizeof(struct generic_timer_cntctrl));
 
-        timer_freq = timer_ctl->CNTDIF0;
+            timer_ctl->CNTCR |= GENERIC_TIMER_CNTCTL_CNTCR_EN;
+            fence_ord_write();
 
-        mem_unmap(&cpu()->as, (vaddr_t)timer_ctl, sizeof(struct generic_timer_cntctrl), false);
+            timer_freq = (uint32_t)timer_ctl->CNTDIF0;
+
+            mem_unmap(&cpu()->as, (vaddr_t)timer_ctl, sizeof(struct generic_timer_cntctrl), false);
+        }
     }
 
     cpu_sync_barrier(&cpu_glb_sync);
 
+    /* Program CNTFRQ_EL0 and verify. */
     sysreg_cntfrq_el0_write(timer_freq);
+    if (sysreg_cntfrq_el0_read() != (unsigned long)timer_freq) {
+        ERROR("failed to program CNTFRQ_EL0 to %u Hz", timer_freq);
+    }
 }

--- a/src/arch/armv8/inc/arch/platform.h
+++ b/src/arch/armv8/inc/arch/platform.h
@@ -32,6 +32,7 @@ struct arch_platform {
 
     struct {
         paddr_t base_addr;
+        uint32_t fixed_freq;
     } generic_timer;
 
     struct clusters {


### PR DESCRIPTION
On armv8r there is no firmware and the system timer must be initialized by the hypevisor. There are multiple cases from where to get the frequecy: (i) it might be fixed already in the hardware, or (ii) it can be retrieved from the plaform level timer if such timer is defined, or (iii) the hypervisor must know by default which is it (which must be defined by platform descrption from the `PLAT_GENERIC_TIMER_FREQ_HZ` macro). This PR handles all this cases.