### PR TITLE
Add mps3 plat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ platforms is presented below:
 
 **Armv8-R AArch32**
 - [x] Arm Fixed Virtual Platforms
+- [x] Arm MPS3-AN536
 - [ ] NXP S32Z/E
 - [ ] Renesas RZT2M
-- [ ] QEMU MPS3-AN536
 
 **RISC-V RV64**
 - [x] QEMU virt

--- a/src/platform/drivers/cmsdk_uart/cmsdk_uart.c
+++ b/src/platform/drivers/cmsdk_uart/cmsdk_uart.c
@@ -1,0 +1,34 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <bao.h>
+#include <drivers/cmsdk_uart.h>
+
+#define CMSDK_UART_STATE_TX_BUF_FULL        (1UL << 0)
+#define CMSDK_UART_STATE_TX_BUF_OVERRUN     (1UL << 2)
+#define CMSDK_UART_STATE_RX_BUF_OVERRUN     (1UL << 3)
+#define CMSDK_UART_CTRL_TXEN                (1UL << 0)
+#define CMSDK_UART_INTSTATUS_TX_IRQ         (1UL << 0)
+#define CMSDK_UART_INTSTATUS_RX_IRQ         (1UL << 1)
+#define CMSDK_UART_INTSTATUS_TX_OVERRUN_IRQ (1UL << 2)
+#define CMSDK_UART_INTSTATUS_RX_OVERRUN_IRQ (1UL << 3)
+
+void uart_init(volatile struct cmsdk_uart_hw* ptr_uart)
+{
+    ptr_uart->state = CMSDK_UART_STATE_TX_BUF_OVERRUN | CMSDK_UART_STATE_RX_BUF_OVERRUN;
+    ptr_uart->intstatus = CMSDK_UART_INTSTATUS_TX_IRQ | CMSDK_UART_INTSTATUS_RX_IRQ |
+        CMSDK_UART_INTSTATUS_TX_OVERRUN_IRQ | CMSDK_UART_INTSTATUS_RX_OVERRUN_IRQ;
+}
+
+void uart_enable(volatile struct cmsdk_uart_hw* ptr_uart)
+{
+    ptr_uart->ctrl = CMSDK_UART_CTRL_TXEN;
+}
+
+void uart_putc(volatile struct cmsdk_uart_hw* ptr_uart, int8_t c)
+{
+    while (ptr_uart->state & CMSDK_UART_STATE_TX_BUF_FULL) { }
+    ptr_uart->data = (uint32_t)c;
+}

--- a/src/platform/drivers/cmsdk_uart/inc/drivers/cmsdk_uart.h
+++ b/src/platform/drivers/cmsdk_uart/inc/drivers/cmsdk_uart.h
@@ -1,0 +1,25 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __CMSDK_UART_H_
+#define __CMSDK_UART_H_
+
+#include <stdint.h>
+
+struct cmsdk_uart_hw {
+    volatile uint32_t data;
+    volatile uint32_t state;
+    volatile uint32_t ctrl;
+    volatile uint32_t intstatus;
+    volatile uint32_t bauddiv;
+} __attribute__((packed));
+
+typedef struct cmsdk_uart_hw bao_uart_t;
+
+void uart_enable(volatile struct cmsdk_uart_hw* ptr_uart);
+void uart_init(volatile struct cmsdk_uart_hw* ptr_uart);
+void uart_putc(volatile struct cmsdk_uart_hw* ptr_uart, int8_t c);
+
+#endif /* __CMSDK_UART_H_ */

--- a/src/platform/drivers/cmsdk_uart/objects.mk
+++ b/src/platform/drivers/cmsdk_uart/objects.mk
@@ -1,0 +1,4 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+drivers-objs-y+=cmsdk_uart/cmsdk_uart.o

--- a/src/platform/mps3-an536/inc/plat/platform.h
+++ b/src/platform/mps3-an536/inc/plat/platform.h
@@ -1,0 +1,11 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __PLAT_PLATFORM_H__
+#define __PLAT_PLATFORM_H__
+
+#include <drivers/cmsdk_uart.h>
+
+#endif

--- a/src/platform/mps3-an536/inc/plat/psci.h
+++ b/src/platform/mps3-an536/inc/plat/psci.h
@@ -1,0 +1,16 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __PLAT_PSCI_H__
+#define __PLAT_PSCI_H__
+
+#define PSCI_POWER_STATE_LVL_0    0x0000000   // TBD
+#define PSCI_POWER_STATE_LVL_1    0x1000000   // TBD
+#define PSCI_POWER_STATE_LVL_2    0x2000000   // TBD
+#define PSCI_STATE_TYPE_STANDBY   0x00000     // TBD
+#define PSCI_STATE_TYPE_POWERDOWN (0UL << 30) // TBD
+#define PSCI_STATE_TYPE_BIT       (0UL << 30) // TBD
+
+#endif                                        // __PLAT_PSCI_H__

--- a/src/platform/mps3-an536/mps3_desc.c
+++ b/src/platform/mps3-an536/mps3_desc.c
@@ -1,0 +1,34 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <platform.h>
+
+struct platform platform = {
+
+    .cpu_num = 2,
+    .cpu_master_fixed = true,
+    .cpu_master = 0,
+
+    .region_num = 1,
+    .regions =  (struct mem_region[]) {
+        {
+            .base = 0x20000000,
+            .size = 0x80000000,
+        }
+    },
+
+    .console = {
+        .base = 0xE0205000,  // UART2
+    },
+
+    .arch = {
+        .gic = {
+            .gicd_addr = 0xF0000000,
+            .gicr_addr = 0xF0100000,
+            .maintenance_id = 25,
+        },
+    },
+
+};

--- a/src/platform/mps3-an536/objects.mk
+++ b/src/platform/mps3-an536/objects.mk
@@ -1,0 +1,4 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+boards-objs-y+=mps3_desc.o

--- a/src/platform/mps3-an536/platform.mk
+++ b/src/platform/mps3-an536/platform.mk
@@ -1,0 +1,18 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+
+ARCH:=armv8
+ARCH_SUB:=aarch32
+ARCH_PROFILE:=armv8-r
+
+GIC_VERSION:=GICV3
+
+drivers = cmsdk_uart
+
+platform_description:=mps3_desc.c
+
+platform-cppflags =
+platform-cflags = -gdwarf-4
+platform-asflags =
+platform-ldflags =


### PR DESCRIPTION
This PR adds support for the cortex-r52 based MPS3 support. See https://documentation-service.arm.com/static/615dbd31ac265639eac54439?token=.

We only tested this support using the QEMU version of the platform (https://www.qemu.org/docs/master/system/arm/mps2.html)

This PR is dependent on #265.