### PR TITLE
fix: vm lock and sync initialization

### DIFF
--- a/src/core/inc/vm.h
+++ b/src/core/inc/vm.h
@@ -113,8 +113,8 @@ struct vm_allocation {
     struct vcpu* vcpus;
 };
 
-struct vm* vm_init(struct vm_allocation* vm_alloc, const struct vm_config* config, bool master,
-    vmid_t vm_id);
+struct vm* vm_init(struct vm_allocation* vm_alloc, struct cpu_synctoken* vm_init_sync,
+    const struct vm_config* config, bool master, vmid_t vm_id);
 void vm_start(struct vm* vm, vaddr_t entry);
 void vm_emul_add_mem(struct vm* vm, struct emul_mem* emu);
 void vm_emul_add_reg(struct vm* vm, struct emul_reg* emu);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -293,8 +293,8 @@ static struct vm* vm_allocation_init(struct vm_allocation* vm_alloc)
     return vm;
 }
 
-struct vm* vm_init(struct vm_allocation* vm_alloc, const struct vm_config* vm_config, bool master,
-    vmid_t vm_id)
+struct vm* vm_init(struct vm_allocation* vm_alloc, struct cpu_synctoken* vm_init_sync,
+    const struct vm_config* vm_config, bool master, vmid_t vm_id)
 {
     struct vm* vm = vm_allocation_init(vm_alloc);
 
@@ -304,6 +304,8 @@ struct vm* vm_init(struct vm_allocation* vm_alloc, const struct vm_config* vm_co
     if (master) {
         vm_master_init(vm, vm_config, vm_id);
     }
+
+    cpu_sync_barrier(vm_init_sync);
 
     /*
      *  Initialize each core.


### PR DESCRIPTION
The vm struct initizalization initializes its internal synchronization primitives, however, itself depends on this primitives. This commit creates a sync primitive during vm assignment and passes it to the vm_init function so it can use it for synchronization before the internal vm sync primitives are initialized.

Also, it fixes the initialization of the lock used for vm cpu assignment.