### PR TITLE
feat(make): make sure executable is not position independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ else ifeq ($(CC_IS_CLANG), y)
 endif
 
 override CFLAGS+=-O$(OPTIMIZATIONS) -Wall -Werror -Wextra $(cflags_warns) \
-	-ffreestanding -std=c11 -fno-pic \
+	-ffreestanding -std=c11 -fno-pic -fno-pie \
 	$(arch-cflags) $(platform-cflags) $(CPPFLAGS) $(debug_flags)
 
 override ASFLAGS+=$(CFLAGS) $(arch-asflags) $(platform-asflags)
@@ -260,6 +260,7 @@ override ASFLAGS+=$(CFLAGS) $(arch-asflags) $(platform-asflags)
 override LDFLAGS+=-build-id=none -nostdlib --fatal-warnings \
 	--defsym=$(version)=0 \
 	-z common-page-size=$(PAGE_SIZE) -z max-page-size=$(PAGE_SIZE) \
+	-no-pie \
 	$(arch-ldflags) $(platform-ldflags)
 
 ifneq ($(build_targets),)


### PR DESCRIPTION
Bao should be compile as position dependent code. Originally we have the -fno-pic option but this prevents only position independent for library binaties (e.g., .so). We want to make sure the final executable is not position independent (albeit this is the default option, we should make it explicit). For this we need to add the no-pie options to compiler and linker flags.