### PR TITLE
ref(mpu): move arch-agnostic prototype to core header

### DIFF
--- a/src/arch/armv8/armv8-r/inc/arch/mpu.h
+++ b/src/arch/armv8/armv8-r/inc/arch/mpu.h
@@ -16,6 +16,4 @@ struct mpu_arch {
     BITMAP_ALLOC(locked_entries, MPU_ARCH_MAX_NUM_ENTRIES);
 };
 
-bool mpu_perms_compatible(unsigned long perms1, unsigned long perms2);
-
 #endif /* __ARCH_MPU_H__ */

--- a/src/core/mpu/inc/mem_prot/mem.h
+++ b/src/core/mpu/inc/mem_prot/mem.h
@@ -59,5 +59,6 @@ void mpu_enable(void);
 bool mpu_map(struct addr_space* as, struct mp_region* mem, bool locked);
 bool mpu_unmap(struct addr_space* as, struct mp_region* mem);
 bool mpu_update(struct addr_space* as, struct mp_region* mpr);
+bool mpu_perms_compatible(unsigned long perms1, unsigned long perms2);
 
 #endif /* __MEM_PROT_H__ */


### PR DESCRIPTION
The `mpu_perms_compatible` is implemented in architecture files, but is agnostic of architecture since it is directly used by the core mpu layer. It should be placed in the core mpu/mem.h header.