### PR TITLE
fix(armv8-r): inter-core coherency before MPU configuration

### DIFF
--- a/src/arch/armv8/armv8-r/aarch32/boot.S
+++ b/src/arch/armv8/armv8-r/aarch32/boot.S
@@ -50,8 +50,8 @@ boot_arch_profile_init:
     /* r4 contains the id of the MPU entry being used */
     mov r4, #(-1)
 
-    /* Enable caches */
-    ldr r4, =(SCTLR_RES1_AARCH32 | SCTLR_C | SCTLR_I)
+    /* Enable instruction cache */
+    ldr r4, =(SCTLR_RES1_AARCH32 | SCTLR_I)
     mcr p15, 4, r4, c1, c0, 0 // HSCTLR
 
     dsb

--- a/src/arch/armv8/armv8-r/mpu.c
+++ b/src/arch/armv8/armv8-r/mpu.c
@@ -202,7 +202,7 @@ void mpu_enable(void)
     unsigned long reg_val;
 
     reg_val = sysreg_sctlr_el2_read();
-    reg_val |= SCTLR_M;
+    reg_val |= (SCTLR_M | SCTLR_C);
     sysreg_sctlr_el2_write(reg_val);
 
     ISB();


### PR DESCRIPTION
This PR aims to fix a coherence issue between cores, which is critical for enabling the use of spinlocks.
In previous versions, the Bao MPU regions were configured (and enabled) during the early boot stages, so this problem did not occur.
However, since all MPU configurations were moved to the `mem_init` function, the shareability attributes of the region where the code is executing no longer match the intended ones.

According to the Cortex-R52 TRM, enabling the data cache before configuring the MPU (i.e., relying on the default background regions) causes the memory to be treated as _Non-shareable_.

The solution is to delay enabling the data cache until the MPU is enabled, and this has been verified on the NXP S32Z270.
