### PR TITLE
ref(arch-profile-init): move arch_profile_init to vm_arch

### DIFF
--- a/src/arch/armv8/armv8-a/vm.c
+++ b/src/arch/armv8/armv8-a/vm.c
@@ -8,10 +8,8 @@
 #include <arch/fences.h>
 #include <tlb.h>
 
-void vcpu_arch_profile_init(struct vcpu* vcpu, struct vm* vm)
+void vm_arch_profile_init(struct vm* vm)
 {
-    UNUSED_ARG(vcpu);
-
     paddr_t root_pt_pa;
     mem_translate(&cpu()->as, (vaddr_t)vm->as.pt.root, &root_pt_pa);
     sysreg_vttbr_el2_write((((uint64_t)vm->id << VTTBR_VMID_OFF) & VTTBR_VMID_MSK) |

--- a/src/arch/armv8/armv8-r/vm.c
+++ b/src/arch/armv8/armv8-r/vm.c
@@ -7,10 +7,8 @@
 #include <config.h>
 #include <arch/sysregs.h>
 
-void vcpu_arch_profile_init(struct vcpu* vcpu, struct vm* vm)
+void vm_arch_profile_init(struct vm* vm)
 {
-    UNUSED_ARG(vcpu);
-
     sysreg_vsctlr_el2_write((vm->id << VSCTLR_EL2_VMID_OFF) & VSCTLR_EL2_VMID_MSK);
 
     if (DEFINED(MEM_PROT_MPU) && DEFINED(AARCH64) && vm->config->platform.mmu) {

--- a/src/arch/armv8/inc/arch/vm.h
+++ b/src/arch/armv8/inc/arch/vm.h
@@ -57,8 +57,9 @@ struct vcpu* vm_get_vcpu_by_mpidr(struct vm* vm, unsigned long mpidr);
 void vcpu_arch_entry(void);
 
 bool vcpu_arch_profile_on(struct vcpu* vcpu);
-void vcpu_arch_profile_init(struct vcpu* vcpu, struct vm* vm);
 void vcpu_subarch_reset(struct vcpu* vcpu);
+
+void vm_arch_profile_init(struct vm* vm);
 
 static inline void vcpu_arch_inject_hw_irq(struct vcpu* vcpu, irqid_t id)
 {

--- a/src/arch/armv8/vm.c
+++ b/src/arch/armv8/vm.c
@@ -11,6 +11,8 @@
 
 void vm_arch_init(struct vm* vm, const struct vm_config* vm_config)
 {
+    vm_arch_profile_init(vm);
+
     if (vm->master == cpu()->id) {
         vgic_init(vm, &vm_config->platform.arch.gic);
     }
@@ -52,8 +54,6 @@ void vcpu_arch_init(struct vcpu* vcpu, struct vm* vm)
 
     vcpu->arch.psci_ctx.state = vcpu->id == 0 ? ON : OFF;
     vcpu->arch.psci_ctx.lock = SPINLOCK_INITVAL;
-
-    vcpu_arch_profile_init(vcpu, vm);
 
     vgic_cpu_init(vcpu);
 }


### PR DESCRIPTION
## PR Description 

The previous function ` vcpu_arch_profile_init`  was called in vcpu_init, and didn't use the vcpu argument. 

This PT moves this function to a more suitable place in vm_arch_init. 
Furthermore, it also solves a dependency problem introduced in #260 . The `vm_vcpu_init` for arm required the as to be initialized, which was being done later in the `vm_mem_prot_init` function ( cc5b20d9eb6fd6786d6190c60532f93caa24682e )