### PR TITLE
ref(mpu): move mmio region init

### DIFF
--- a/src/core/mpu/inc/mem_prot/mem.h
+++ b/src/core/mpu/inc/mem_prot/mem.h
@@ -46,6 +46,7 @@ static inline bool mem_regions_overlap(struct mp_region* reg1, struct mp_region*
 }
 
 bool mem_map(struct addr_space* as, struct mp_region* mpr, bool broadcast, bool locked);
+void mem_mmio_init_regions(struct addr_space* as);
 
 /**
  * This functions must be defined for the physical MPU. The abstraction provided by the physical

--- a/src/core/mpu/vm.c
+++ b/src/core/mpu/vm.c
@@ -10,4 +10,8 @@ void vm_mem_prot_init(struct vm* vm, const struct vm_config* config)
     UNUSED_ARG(config);
 
     as_init(&vm->as, AS_VM, 0);
+
+    if (DEFINED(MMIO_SLAVE_SIDE_PROT) && (vm->master == cpu()->id)) {
+        mem_mmio_init_regions(&vm->as);
+    }
 }


### PR DESCRIPTION
This is done so that this region is not created specifically for each cpu address space, but only once by the master cpu and globally.