### PR TITLE
fix(config): add missing shared memory header

### DIFF
--- a/src/core/inc/config.h
+++ b/src/core/inc/config.h
@@ -10,6 +10,7 @@
 #include <platform.h>
 #include <vm.h>
 #include <config_defs.h>
+#include <shmem.h>
 
 #ifndef GENERATING_DEFS
 // clang-format wont correctly recognize the syntax of assembly strings interleaved with


### PR DESCRIPTION
After the commit [eabe82727be4952e176b8951b718709fbf957663](https://github.com/bao-project/bao-hypervisor/commit/eabe82727be4952e176b8951b718709fbf957663), each Bao demo would need to explicitly include the shared memory header in its configuration. In this commit, we add it to Bao’s main configuration file, so it no longer needs to be added manually to every demo configuration.