### PR TITLE
fix(rpi): psci error on powerdown and standy

### DIFF
--- a/src/platform/rpi4/inc/plat/psci.h
+++ b/src/platform/rpi4/inc/plat/psci.h
@@ -6,9 +6,15 @@
 #ifndef __PLAT_PSCI_H__
 #define __PLAT_PSCI_H__
 
-#define PSCI_POWER_STATE_LVL_0    0x0000002
-#define PSCI_STATE_TYPE_STANDBY   0x0000000
-#define PSCI_STATE_TYPE_BIT       (1UL << 16)
-#define PSCI_STATE_TYPE_POWERDOWN PSCI_STATE_TYPE_BIT
+#define PSCI_POWER_STATE_LVL_0            0x0000002
+#define PSCI_STATE_TYPE_STANDBY           0x0000000
+#define PSCI_STATE_TYPE_BIT               (1UL << 16)
+#define PSCI_STATE_ID_RETENTION           0x2
+#define PSCI_STATE_TYPE_POWERDOWN         PSCI_STATE_TYPE_BIT | PSCI_STATE_ID_RETENTION
+
+/* Bao invokes PSCI_SUSPEND to achieve powerdown and standby, however RPi's
+ * TF-A psci does not implement a psci_suspend handler. */
+#define PLAT_PSCI_POWERDOWN_NOT_SUPPORTED 1
+#define PLAT_PSCI_STANDBY_NOT_SUPPORTED   1
 
 #endif // __PLAT_PSCI_H__


### PR DESCRIPTION
Bao invokes PSCI_SUSPEND to achieve powerdown and standby, however RPi's TF-A PSCI does not implement a psci_suspend handler.