### PR TITLE
Fix AIA physical interrupt id and hypervisor msi id in `vm_has_interrupt` check

### DIFF
--- a/src/arch/armv8/inc/arch/interrupts.h
+++ b/src/arch/armv8/inc/arch/interrupts.h
@@ -13,4 +13,16 @@
 #define MAX_INTERRUPT_HANDLERS GIC_MAX_INTERUPTS
 #define MAX_GUEST_INTERRUPTS   GIC_MAX_INTERUPTS
 
+static inline bool interrupts_arch_irq_is_forwardable(irqid_t int_id)
+{
+    UNUSED_ARG(int_id);
+
+    /**
+     * In Arm GIC systems all interrupts must be trapped and considered
+     * to be forwarded to guests.
+     */
+
+    return true;
+}
+
 #endif /* __ARCH_INTERRUPTS_H__ */

--- a/src/arch/riscv/inc/arch/interrupts.h
+++ b/src/arch/riscv/inc/arch/interrupts.h
@@ -23,4 +23,23 @@ extern irqid_t irqc_timer_int_id;
 
 void interrupts_arch_handle(void);
 
+static inline bool interrupts_arch_irq_is_forwardable(irqid_t int_id)
+{
+    UNUSED_ARG(int_id);
+
+    /**
+     * Under full AIA support, interrupts delivered to HS mode are always
+     * reserved for the hypervisor. Guest-directed interrupts are forwarded to
+     * the guest interrupt files and do not arrive at the hypervisor handler. Any
+     * guest-related interrupt trapping is signaled via the dedicated
+     * "Supervisor guest external interrupt" id which can be handled by the
+     * hypervisor in the future.
+     *
+     * Only for PLIC and APLIC-only systems interrupts need to be re-directed
+     * to guests.
+     */
+
+    return IRQC != AIA;
+}
+
 #endif /* __ARCH_INTERRUPTS_H__ */

--- a/src/core/interrupts.c
+++ b/src/core/interrupts.c
@@ -90,7 +90,7 @@ static inline bool interrupt_assigned(irqid_t int_id)
 
 enum irq_res interrupts_handle(irqid_t int_id)
 {
-    if (vm_has_interrupt(cpu()->vcpu->vm, int_id)) {
+    if (interrupts_arch_irq_is_forwardable(int_id) && vm_has_interrupt(cpu()->vcpu->vm, int_id)) {
         vcpu_inject_hw_irq(cpu()->vcpu, int_id);
 
         return FORWARD_TO_VM;


### PR DESCRIPTION
For risc-v full AIA systems, there might be a conflict between the MSI ids allocated for the hypervisor and the physical line irq ids assigned to virtual machine (e.g., irq 1 is assigned to a vm, while the hypervisor allocated MSI id 1 for itself). In this case, when the hypervisor receives MSI with ID 1 and checks if the irq was assigned to the vm, `vm_has_interrupt` will return true and the hypervisor will inject it in the vm, when it should handle it itself. This issue was dectected by @filippofontana.

To solve this, we create `interrupts_arch_irq_is_forwardable`. For systems which don't require reinjection (as is the case for risc-v AIA systems, where no interrupts received by the hypervisor should be forward to the guest, since guest interrupts are directed to the guest interrupt file), this function will return false and the `vm_has_interrupt` check is skipped avoiding the conflict. For other systems, most interrupts will be forwardable by default, but this can be adapted according to each architecture interrupt injection support.

I am still not fully comfortable with this solution since the namespace collision between MSI IDs and physical interrupt line IDs still exists in the codebase. This PR aims to fix the immediate issue while avoiding a larger refactoring. I think it’s sufficient for now, but we should address the collision in the future.