### PR TITLE
fix(mpu_mask): move mpu_entry_mask from vm struct to vcpu

### DIFF
--- a/src/arch/armv8/aarch32/exceptions.S
+++ b/src/arch/armv8/aarch32/exceptions.S
@@ -52,8 +52,7 @@
 
 #ifdef MEM_PROT_MPU
     mrc p15, 4, r0, c13, c0, 2  // Read HTPIDR (CPU base address)
-    add r0, r0, #CPU_AS_ARCH_MASK_OFF
-    ldr r0, [r0]
+    ldr r0, [r0, #CPU_ARCH_PROFILE_MPU_MASK_OFF]
     mcr p15, 4, r0, c6, c1, 1
 #endif /* MEM_PROT_MPU */
 
@@ -65,10 +64,7 @@
 
 #ifdef MEM_PROT_MPU
     ldr r1, [r0, #CPU_VCPU_OFF]
-    mov r2, #VCPU_VM_OFF
-    add r1, r1, r2
-    ldr r1, [r1]
-    ldr r1, [r1, #VM_AS_ARCH_MASK_OFF]
+    ldr r1, [r1, #VCPU_ARCH_MASK_OFF]
 
     mov r2, #CPU_ARCH_PROFILE_MPU_LOCKED_OFF
     add r2, r2, r0

--- a/src/arch/armv8/aarch64/exceptions.S
+++ b/src/arch/armv8/aarch64/exceptions.S
@@ -66,8 +66,7 @@
 
     #ifdef MEM_PROT_MPU
     mrs x0, tpidr_el2
-    add x0, x0, #CPU_AS_ARCH_MASK_OFF
-    ldr x0, [x0]
+    ldr x0, [x0, #CPU_ARCH_PROFILE_MPU_MASK_OFF]
     msr prenr_el2, x0
     #endif /* MEM_PROT_MPU */
 
@@ -79,10 +78,7 @@ vcpu_arch_entry:
 
     #ifdef MEM_PROT_MPU
     ldr x1, [x0, #CPU_VCPU_OFF]
-    mov x2, #VCPU_VM_OFF
-    add x1, x1, x2
-    ldr x1, [x1]
-    ldr x1, [x1, #VM_AS_ARCH_MASK_OFF]
+    ldr x1, [x1, #VCPU_ARCH_MASK_OFF]
 
     mov x2, #CPU_ARCH_PROFILE_MPU_LOCKED_OFF
     add x2, x2, x0

--- a/src/arch/armv8/armv8-r/inc/arch/mem.h
+++ b/src/arch/armv8/armv8-r/inc/arch/mem.h
@@ -36,10 +36,6 @@ typedef union {
     };
 } mem_flags_t;
 
-struct addr_space_arch {
-    unsigned long mpu_entry_mask;
-};
-
 #define PTE_FLAGS(_prbar, _prlar) \
     ((mem_flags_t){               \
         .prbar = (_prbar),        \

--- a/src/arch/armv8/armv8-r/inc/arch/mpu.h
+++ b/src/arch/armv8/armv8-r/inc/arch/mpu.h
@@ -15,6 +15,7 @@ struct mpu_arch {
     BITMAP_ALLOC(allocated_entries, MPU_ARCH_MAX_NUM_ENTRIES);
     BITMAP_ALLOC(locked_entries, MPU_ARCH_MAX_NUM_ENTRIES);
     asid_t entry_asid[MPU_ARCH_MAX_NUM_ENTRIES];
+    unsigned long mpu_entry_mask;
 };
 
 #endif /* __ARCH_MPU_H__ */

--- a/src/arch/armv8/armv8-r/mem.c
+++ b/src/arch/armv8/armv8-r/mem.c
@@ -7,5 +7,5 @@
 
 void as_arch_init(struct addr_space* as)
 {
-    as->arch.mpu_entry_mask = 0;
+    UNUSED_ARG(as);
 }

--- a/src/arch/armv8/asm_defs.c
+++ b/src/arch/armv8/asm_defs.c
@@ -19,8 +19,8 @@ __attribute__((used)) static void cpu_defines(void)
     DEFINE_OFFSET(CPU_VCPU_OFF, struct cpu, vcpu);
 
 #ifdef MEM_PROT_MPU
-    DEFINE_OFFSET(CPU_AS_ARCH_MASK_OFF, struct cpu, as.arch.mpu_entry_mask);
     DEFINE_OFFSET(CPU_ARCH_PROFILE_MPU_LOCKED_OFF, struct cpu, arch.profile.mpu.locked_entries);
+    DEFINE_OFFSET(CPU_ARCH_PROFILE_MPU_MASK_OFF, struct cpu, arch.profile.mpu.mpu_entry_mask);
 #endif /* MEM_PROT_MPU */
 }
 
@@ -32,7 +32,7 @@ __attribute__((used)) static void vcpu_defines(void)
     DEFINE_SIZE(VCPU_REGS_SIZE, struct arch_regs);
 
 #ifdef MEM_PROT_MPU
-    DEFINE_OFFSET(VM_AS_ARCH_MASK_OFF, struct vm, as.arch.mpu_entry_mask);
+    DEFINE_OFFSET(VCPU_ARCH_MASK_OFF, struct vcpu, arch.mpu_entry_mask);
 #endif /* MEM_PROT_MPU */
 }
 

--- a/src/arch/armv8/inc/arch/vm.h
+++ b/src/arch/armv8/inc/arch/vm.h
@@ -51,6 +51,10 @@ struct vcpu_arch {
     struct vgic_priv vgic_priv;
     struct list vgic_spilled;
     struct psci_ctx psci_ctx;
+
+#ifdef MEM_PROT_MPU
+    unsigned long mpu_entry_mask;
+#endif
 };
 
 struct vcpu* vm_get_vcpu_by_mpidr(struct vm* vm, unsigned long mpidr);

--- a/src/core/mpu/inc/mem_prot/mem.h
+++ b/src/core/mpu/inc/mem_prot/mem.h
@@ -24,7 +24,6 @@ struct addr_space {
     asid_t id;
     enum AS_TYPE type;
     colormap_t colors;
-    struct addr_space_arch arch;
     struct {
         struct list ordered_list;
         struct mpe {


### PR DESCRIPTION
## PR Description

This PR addresses issue https://github.com/bao-project/bao-hypervisor/issues/290 

The entry mask being in the vm struct made so that all cpus would use the same mask and change it for all other cpus.
This PR fixes this by moving the mask to the vcpu struct.