### PR TITLE
ref(riscv/aia): minimize aia irqc conditional compilation

### DIFF
--- a/src/arch/riscv/irqc/aia/aplic.c
+++ b/src/arch/riscv/irqc/aia/aplic.c
@@ -47,9 +47,9 @@ void aplic_init(void)
     }
     APLIC_IPRIO_MASK = aplic_control->target[0] & APLIC_TARGET_IPRIO_MASK;
     aplic_control->domaincfg |= APLIC_DOMAINCFG_IE;
-#if (IRQC == AIA)
-    aplic_control->domaincfg |= APLIC_DOMAINCFG_DM;
-#endif
+    if (IRQC == AIA) {
+        aplic_control->domaincfg |= APLIC_DOMAINCFG_DM;
+    }
 }
 
 void aplic_idc_init(void)

--- a/src/arch/riscv/irqc/aia/inc/aplic.h
+++ b/src/arch/riscv/irqc/aia/inc/aplic.h
@@ -26,6 +26,8 @@ typedef cpuid_t idcid_t;
 #define APLIC_NUM_SETIx_REGS          (APLIC_MAX_INTERRUPTS / 32)
 #define APLIC_NUM_INTP_PER_REG        (APLIC_MAX_INTERRUPTS / APLIC_NUM_SETIx_REGS)
 
+#define APLIC_MIN_PRIO                (0xFF)
+
 /** Source Mode defines */
 #define APLIC_SOURCECFG_SM_MASK       (0x00000007U)
 #define APLIC_SOURCECFG_SM_INACTIVE   (0x0U)

--- a/src/platform/qemu-riscv64-virt/virt_desc.c
+++ b/src/platform/qemu-riscv64-virt/virt_desc.c
@@ -30,16 +30,10 @@ struct platform platform = {
     .arch = {
 #if (IRQC == PLIC)
         .irqc.plic.base = 0xc000000,
-#elif (IRQC == APLIC)
-        .irqc.aia.aplic.base = 0xd000000,
-#elif (IRQC == AIA)
+#else
         .irqc.aia.aplic.base = 0xd000000,
         .irqc.aia.imsic.base = 0x28000000,
         .irqc.aia.imsic.num_msis = 255,
-#else
-#error "unknown IRQC type " IRQC
-#endif
-#if (IPIC == IPIC_ACLINT)
         .aclint_sswi.base = 0x2f00000,
 #endif
     },


### PR DESCRIPTION
RISC-V AIA depended too much on conditional compilation to distinguish the cases of APLIC-only and full AIA systems (w/ IMSICs) making the code too clutered. This PR aims at minimizing the use of the precompiler to make the code more readble.

It mainly replaces the `#ifdef` statements with direct `if` statements, leaving to the compiler to remove the branches that are never executable, which is possible since the conditions only depend on constant macros.