### PR TITLE
fix(mpu): add dsb barrier to mpu enable

### DIFF
--- a/src/arch/armv8/armv8-r/mpu.c
+++ b/src/arch/armv8/armv8-r/mpu.c
@@ -170,6 +170,8 @@ void mpu_enable(void)
     reg_val |= (SCTLR_M | SCTLR_C);
     sysreg_sctlr_el2_write(reg_val);
 
+    /* Make sure that all the registers are set before proceeding */
+    DSB(ish);
     ISB();
 }
 


### PR DESCRIPTION
This PR adds the required `DSB` after enabling the MPU and data cache. A `DSB` followed by an `ISB` is architecturally required after changing `SCTLR` to ensure all memory-system updates complete and the pipeline is synchronized to the new configuration.

Tested with NXP S32Z. 