### PR TITLE
feat(plat): add plat-specific cpu init function

### DIFF
--- a/src/arch/armv8/armv8-r/cpu.c
+++ b/src/arch/armv8/armv8-r/cpu.c
@@ -4,12 +4,20 @@
  */
 
 #include <cpu.h>
+#include <platform.h>
 #include <arch/gic.h>
 
 void cpu_arch_profile_init(cpuid_t cpuid, paddr_t load_addr)
 {
-    UNUSED_ARG(cpuid);
-    UNUSED_ARG(load_addr);
+    if (cpuid == CPU_MASTER) {
+        for (size_t cpu_core_id = 0; cpu_core_id < platform.cpu_num; cpu_core_id++) {
+            if (cpu_core_id == cpuid) {
+                continue;
+            }
+
+            plat_cpu_init(cpu_core_id, load_addr);
+        }
+    }
 }
 
 void cpu_arch_profile_standby()

--- a/src/core/inc/platform.h
+++ b/src/core/inc/platform.h
@@ -37,5 +37,6 @@ extern struct platform platform;
 void platform_init(void);
 void platform_default_init(void);
 void platform_config_init(void);
+void plat_cpu_init(cpuid_t cpuid, paddr_t load_addr);
 
 #endif /* __PLATFORM_H__ */

--- a/src/core/platform.c
+++ b/src/core/platform.c
@@ -9,6 +9,13 @@ __attribute__((weak)) void platform_default_init(void) { }
 
 __attribute__((weak)) void platform_config_init(void) { }
 
+__attribute__((weak)) void plat_cpu_init(cpuid_t cpuid, paddr_t load_addr)
+{
+    UNUSED_ARG(cpuid);
+    UNUSED_ARG(load_addr);
+    return;
+}
+
 void platform_init(void)
 {
     platform_default_init();


### PR DESCRIPTION
This PR introduces support for per-core CPU initialization in the ARMv8-R architecture. The main change is the addition of a new `plat_cpu_init` function, which allows platform-specific initialization for each CPU core.

* Added the `plat_cpu_init` function prototype to `platform.h` and provided a weak default implementation in `platform.c`, allowing platforms to override this function for custom per-core initialization.
* Modified `cpu_arch_profile_init` in `cpu.c` to call `plat_cpu_init` for each secondary CPU core during initialization, skipping the master core. 