### PR TITLE
fix(riscv/aia): fix imsic eie index calculation

### DIFF
--- a/src/arch/riscv/irqc/aia/imsic.c
+++ b/src/arch/riscv/irqc/aia/imsic.c
@@ -15,11 +15,10 @@ BITMAP_ALLOC(msi_reserved, IMSIC_MAX_INTERRUPTS);
 
 static inline size_t imsic_eie_index(irqid_t int_id)
 {
-    size_t index = int_id / __riscv_xlen;
-    bool index_is_odd = (index & 1) != 0;
+    size_t index = int_id / 32U;
 
-    if ((__riscv_xlen == 64) && index_is_odd) {
-        index -= 1;
+    if (__riscv_xlen == 64) {
+        index &= ~1UL;
     }
 
     return index;


### PR DESCRIPTION
On RV64, IMSIC EIE registers are sparsely numbered (eie0, eie2, eie4, …), with each implemented register covering 64 interrupt identities. The previous calculation divided by XLEN and folded odd indices, which incorrectly mapped, for example, interrupt IDs 64–127 back onto eie0.

This patch fixes the index calculation by deriving the register number in 32-ID units and forcing even indices on RV64, yielding the correct sparse layout.