### PR TITLE
fix(riscv/aia): imsic offset depends on number of guest files

### DIFF
--- a/scripts/arch/riscv/platform_defs_gen.c
+++ b/scripts/arch/riscv/platform_defs_gen.c
@@ -14,6 +14,17 @@ void arch_platform_defs() {
 
     if (IRQC == AIA) {
         printf("#define PLAT_IMSIC_MAX_INTERRUPTS %ld\n", platform.arch.irqc.aia.imsic.num_msis);
+
+        /**
+         * This calculation follows the rules for the arrangement of memory regions for multiple
+         * interrupt files defined in section 3.6 of "The RISC-V Advanced Interrupt Architecture"
+         * version 1.0, with the smallest constant D as defined by the spec.
+         */
+        size_t num_addr_bits = 0;
+        while ((1UL << num_addr_bits) < (platform.arch.irqc.aia.imsic.num_guest_files + 1)) {
+            num_addr_bits += 1;
+        }
+        printf("#define PLAT_IMSIC_HART_SIZE (%ld)\n", ((1UL << (num_addr_bits)) * PAGE_SIZE));
     }
 
 }

--- a/src/arch/riscv/inc/arch/platform.h
+++ b/src/arch/riscv/inc/arch/platform.h
@@ -25,6 +25,7 @@ struct arch_platform {
             struct {
                 paddr_t base;
                 size_t num_msis;
+                size_t num_guest_files;
             } imsic;
         } aia;
     } irqc;

--- a/src/arch/riscv/irqc/aia/imsic.c
+++ b/src/arch/riscv/irqc/aia/imsic.c
@@ -45,7 +45,7 @@ void imsic_init(void)
 
     /** Map the interrupt files */
     imsic[cpu()->id] = (void*)mem_alloc_map_dev(&cpu()->as, SEC_HYP_GLOBAL, INVALID_VA,
-        platform.arch.irqc.aia.imsic.base + (cpu()->id * PAGE_SIZE * IMSIC_NUM_FILES),
+        platform.arch.irqc.aia.imsic.base + (cpu()->id * PLAT_IMSIC_HART_SIZE),
         NUM_PAGES(sizeof(struct imsic_global_hw)));
 }
 

--- a/src/arch/riscv/irqc/aia/inc/imsic.h
+++ b/src/arch/riscv/irqc/aia/inc/imsic.h
@@ -10,9 +10,6 @@
 #include <platform.h>
 
 #define IMSIC_MAX_INTERRUPTS (PLAT_IMSIC_MAX_INTERRUPTS)
-/** We only support 1 guest per hart at the moment */
-#define IMSIC_NUM_VS_FILES   (1)
-#define IMSIC_NUM_FILES      (IMSIC_NUM_VS_FILES + 1)
 
 #define STOPEI_EEID          (16)
 

--- a/src/arch/riscv/irqc/aia/vimsic.c
+++ b/src/arch/riscv/irqc/aia/vimsic.c
@@ -21,8 +21,8 @@ void vimsic_init(struct vm* vm, const union vm_irqc_dscrp* vm_irqc_dscrp)
 
     imsic_vaddr = vm_irqc_dscrp->aia.imsic.base + (PAGE_SIZE * vcpu_id);
 
-    imsic_paddr = platform.arch.irqc.aia.imsic.base +
-        (PAGE_SIZE * ((IMSIC_NUM_FILES * pcpu_id) + VS_FILE_IDX));
+    imsic_paddr = platform.arch.irqc.aia.imsic.base + (PLAT_IMSIC_HART_SIZE * pcpu_id) +
+        (PAGE_SIZE * VS_FILE_IDX);
 
     if (imsic_vaddr != INVALID_VA) {
         mem_alloc_map_dev(&vm->as, SEC_VM_ANY, imsic_vaddr, imsic_paddr, 1);

--- a/src/platform/qemu-riscv64-virt/virt_desc.c
+++ b/src/platform/qemu-riscv64-virt/virt_desc.c
@@ -35,6 +35,7 @@ struct platform platform = {
         .irqc.aia.aplic.base = 0xd000000,
         .irqc.aia.imsic.base = 0x28000000,
         .irqc.aia.imsic.num_msis = 255,
+        .irqc.aia.imsic.num_guest_files = 1,
 #endif
 
 #if (IPIC == IPIC_ACLINT)


### PR DESCRIPTION
Previously the implementation assumed a single guest interrupt file per IMSIC. With this all interrupt files were contiguous in memory and the offset between each hart's interrupt files' base was two pages (s- and vs- level respectively). However, when the number of guest interrupt files is larger than 1, this is not true. This patch removes this assumption and calculates the size of each IMSIC memory address range (and therfore, offset between each hart's IMSIC base address) according to the layout mandated in the AIA spec version 1, which is depentent on GEILEN.