### PR TITLE
ref(riscv): refactor vimsic interrupt injection

### DIFF
--- a/src/arch/riscv/irqc/aia/imsic.c
+++ b/src/arch/riscv/irqc/aia/imsic.c
@@ -67,23 +67,6 @@ void imsic_clr_pend(irqid_t intp_id)
     csrs_sireg_clear(1UL << imsic_eie_bit(intp_id));
 }
 
-/**
- * For now we only support 1 guest file per hart.
- * Should I remove the guest_file from the API?
- */
-void imsic_inject_pend(size_t guest_file, irqid_t intp_id)
-{
-    UNUSED_ARG(guest_file);
-
-    csrs_vsiselect_write(IMSIC_EIP + imsic_eie_index(intp_id));
-    csrs_vsireg_clear(1UL << imsic_eie_bit(intp_id));
-}
-
-void imsic_send_msi(cpuid_t target_cpu)
-{
-    imsic[target_cpu]->s_file.seteipnum_le = interrupts_ipi_id;
-}
-
 void imsic_handle(void)
 {
     /* Read STOPEI and write to it to claim the interrupt */

--- a/src/arch/riscv/irqc/aia/inc/imsic.h
+++ b/src/arch/riscv/irqc/aia/inc/imsic.h
@@ -25,7 +25,10 @@ struct imsic_intp_file_hw {
 
 struct imsic_global_hw {
     struct imsic_intp_file_hw s_file;
+    struct imsic_intp_file_hw guest_file;
 } __attribute__((__packed__, aligned(0x1000ULL)));
+
+extern volatile struct imsic_global_hw* imsic[PLAT_CPU_NUM];
 
 /**
  * @brief Initializes the IMSIC
@@ -68,16 +71,28 @@ void imsic_set_enbl(irqid_t intp_id);
  *        Only little endian is supported.
  *
  * @param target_cpu The ID of the target CPU
+ * @param msi_id The MSI ID to be sent
  */
-void imsic_send_msi(cpuid_t target_cpu);
+static inline void imsic_send_msi(cpuid_t target_cpu, irqid_t msi_id)
+{
+    imsic[target_cpu]->s_file.seteipnum_le = msi_id;
+}
 
 /**
- * @brief Inject an interrupt into a guest.
+ * @brief Sends an MSI to the guest file of specified CPU with the specified IPI ID.
  *
- * @param guest_file Guest interrupt file ID
- * @param intp_id Interrupt ID
+ *        The function sends an MSI to the target CPU's guest file by setting the seteipnum_le
+ *        register in the IMSIC. The seteipnum_le register is used to specify the ID of the
+ *        interrupt being sent. Only little endian is supported. This function assume a single guest
+ *        interrupt file per hart.
+ *
+ * @param target_cpu The ID of the target CPU
+ * @param msi_id The MSI ID to be injected in the guest interrupt file
  */
-void imsic_inject_pend(size_t guest_file, irqid_t intp_id);
+static inline void imsic_send_guest_msi(cpuid_t target_cpu, irqid_t msi_id)
+{
+    imsic[target_cpu]->guest_file.seteipnum_le = msi_id;
+}
 
 /**
  * @brief Handles interrupts in the IMSIC.

--- a/src/arch/riscv/irqc/aia/inc/irqc.h
+++ b/src/arch/riscv/irqc/aia/inc/irqc.h
@@ -91,7 +91,8 @@ static inline irqid_t irqc_reserve(irqid_t pintp_id)
 
 static inline void irqc_send_ipi(cpuid_t target_cpu)
 {
-    imsic_send_msi(target_cpu);
+    extern irqid_t interrupts_ipi_id;
+    imsic_send_msi(target_cpu, interrupts_ipi_id);
 }
 
 static inline void irqc_handle(void)

--- a/src/arch/riscv/irqc/aia/vaplic.c
+++ b/src/arch/riscv/irqc/aia/vaplic.c
@@ -33,17 +33,6 @@ static inline bool vaplic_intp_valid(irqid_t intp_id)
     return intp_id != 0 && intp_id < APLIC_MAX_INTERRUPTS;
 }
 
-/**
- * @brief Converts a virtual cpu id into the physical one
- *
- * @param vcpu Virtual cpu to convert
- * @return int The physical cpu id; or INVALID_CPUID in case of error.
- */
-static inline cpuid_t vaplic_vcpuid_to_pcpuid(struct vcpu* vcpu, vcpuid_t vhart)
-{
-    return vm_translate_to_pcpuid(vcpu->vm, vhart);
-}
-
 static uint32_t vaplic_get_domaincfg(struct vcpu* vcpu);
 static uint32_t vaplic_get_target(struct vcpu* vcpu, irqid_t intp_id);
 
@@ -162,16 +151,23 @@ static bool vaplic_set_pend(struct vcpu* vcpu, irqid_t intp_id)
     return ret;
 }
 
-enum { UPDATE_HART_LINE };
-static void vaplic_ipi_handler(uint32_t event, uint64_t data);
-CPU_MSG_HANDLER(vaplic_ipi_handler, VPLIC_IPI_ID)
-
 #if (IRQC == APLIC)
 
 static uint32_t vaplic_get_idelivery(struct vcpu* vcpu, idcid_t idc_id);
 static uint32_t vaplic_get_iforce(struct vcpu* vcpu, idcid_t idc_id);
 static uint32_t vaplic_get_ithreshold(struct vcpu* vcpu, idcid_t idc_id);
-static void vaplic_update_hart(struct vcpu* vcpu, size_t vhart_index);
+static void vaplic_update_hart(struct vcpu* vcpu, size_t vhart_index, irqid_t irq_id);
+
+/**
+ * @brief Converts a virtual cpu id into the physical one
+ *
+ * @param vcpu Virtual cpu to convert
+ * @return int The physical cpu id; or INVALID_CPUID in case of error.
+ */
+static inline cpuid_t vaplic_vcpuid_to_pcpuid(struct vcpu* vcpu, vcpuid_t vhart)
+{
+    return vm_translate_to_pcpuid(vcpu->vm, vhart);
+}
 
 /**
  * @brief Updates the topi register with with the highest pend & en interrupt id
@@ -223,6 +219,10 @@ static bool vaplic_update_topi(struct vcpu* vcpu)
     return ret;
 }
 
+enum { UPDATE_HART_LINE };
+static void vaplic_ipi_handler(uint32_t event, uint64_t data);
+CPU_MSG_HANDLER(vaplic_ipi_handler, VPLIC_IPI_ID)
+
 /**
  * @brief Updates the interrupt line for a single hart
  *
@@ -250,6 +250,24 @@ static void vaplic_update_hart_line(struct vcpu* vcpu, vcpuid_t vhart_index)
 }
 
 /**
+ * @brief Processes an incoming event.
+ *
+ * @param event the event id
+ * @param data
+ */
+static void vaplic_ipi_handler(uint32_t event, uint64_t data)
+{
+    switch (event) {
+        case UPDATE_HART_LINE:
+            vaplic_update_hart(cpu()->vcpu, (size_t)data, INVALID_IRQID);
+            break;
+        default:
+            WARNING("Unknown VAPLIC IPI event");
+            break;
+    }
+}
+
+/**
  * @brief Set idelivery register for a given idc.
  *
  * @param vcpu virtual CPU
@@ -267,7 +285,7 @@ static void vaplic_set_idelivery(struct vcpu* vcpu, idcid_t idc_id, uint32_t new
             bitmap_clear(vaplic->idelivery, idc_id);
         }
     }
-    vaplic_update_hart(vcpu, idc_id);
+    vaplic_update_hart(vcpu, idc_id, INVALID_IRQID);
     spin_unlock(&vaplic->lock);
 }
 
@@ -306,7 +324,7 @@ static void vaplic_set_iforce(struct vcpu* vcpu, idcid_t idc_id, uint32_t new_va
             bitmap_clear(vaplic->iforce, idc_id);
         }
     }
-    vaplic_update_hart(vcpu, idc_id);
+    vaplic_update_hart(vcpu, idc_id, INVALID_IRQID);
     spin_unlock(&vaplic->lock);
 }
 
@@ -341,7 +359,7 @@ static void vaplic_set_ithreshold(struct vcpu* vcpu, idcid_t idc_id, uint32_t ne
     if (idc_id < vaplic->idc_num) {
         vaplic->ithreshold[idc_id] = new_val & APLIC_IPRIO_MASK;
     }
-    vaplic_update_hart(vcpu, idc_id);
+    vaplic_update_hart(vcpu, idc_id, INVALID_IRQID);
     spin_unlock(&vaplic->lock);
 }
 
@@ -401,7 +419,7 @@ static uint32_t vaplic_get_claimi(struct vcpu* vcpu, idcid_t idc_id)
         if (ret == 0) {
             bitmap_clear(vaplic->iforce, idc_id);
         }
-        vaplic_update_hart(vcpu, idc_id);
+        vaplic_update_hart(vcpu, idc_id, INVALID_IRQID);
     }
     spin_unlock(&vaplic->lock);
     return ret;
@@ -526,53 +544,6 @@ static bool vaplic_idc_emul_handler(struct emul_access* acc)
     return true;
 }
 
-#elif (IRQC == AIA)
-
-/**
- * @brief Returns the target guest index of a given interrupt
- *
- * @param vcpu virtual cpu
- * @param intp_id interrupt ID
- * @return uint8_t guest hart index of the given interrupt
- */
-static inline uint8_t vaplic_get_target_guest(struct vcpu* vcpu, irqid_t intp_id)
-{
-    return (vaplic_get_target(vcpu, intp_id) >> APLIC_TARGET_GUEST_IDX_SHIFT) &
-        APLIC_TARGET_GUEST_INDEX_MASK;
-}
-
-static void vaplic_update_hart_imsic(struct vcpu* vcpu, vcpuid_t vhart_index)
-{
-    struct vaplic* vaplic = &vcpu->vm->arch.vaplic;
-    cpuid_t pcpu_id = vaplic_vcpuid_to_pcpuid(vcpu, vhart_index);
-    bool domain_enbl = !!(vaplic_get_domaincfg(vcpu) & APLIC_DOMAINCFG_IE);
-    size_t target_guest = 0;
-
-    if (pcpu_id == cpu()->id) {
-        for (irqid_t i = 1; i < APLIC_MAX_INTERRUPTS; i++) {
-            if ((vaplic_get_hart_index(vcpu, i) == vcpu->id) && vaplic_get_pend(vcpu, i) &&
-                vaplic_get_enbl(vcpu, i) && domain_enbl) {
-                target_guest = vaplic_get_target_guest(vcpu, i);
-                imsic_inject_pend(target_guest, i);
-                CLR_INTP_REG(vaplic->ip, i);
-            }
-        }
-    } else {
-        struct cpu_msg msg = { (uint32_t)VPLIC_IPI_ID, UPDATE_HART_LINE, vhart_index };
-        cpu_send_msg(pcpu_id, &msg);
-    }
-}
-#endif
-
-static inline void vaplic_update_hart_impl(struct vcpu* vcpu, vcpuid_t vhart_index)
-{
-#if (IRQC == APLIC)
-    vaplic_update_hart_line(vcpu, vhart_index);
-#elif (IRQC == AIA)
-    vaplic_update_hart_imsic(vcpu, vhart_index);
-#endif
-}
-
 /**
  * @brief Triggers the hart/harts interrupt line update.
  *
@@ -581,36 +552,80 @@ static inline void vaplic_update_hart_impl(struct vcpu* vcpu, vcpuid_t vhart_ind
  *        this function will trigger the interrupt line update to all virtual harts running in this
  *        vm.
  */
-static void vaplic_update_hart(struct vcpu* vcpu, size_t vhart_index)
+static void vaplic_update_hart(struct vcpu* vcpu, size_t vhart_index, irqid_t irq_id)
 {
     struct vaplic* vaplic = &vcpu->vm->arch.vaplic;
 
+    UNUSED_ARG(irq_id);
+
     if (vhart_index == UPDATE_ALL_HARTS) {
         for (size_t i = 0; i < vaplic->idc_num; i++) {
-            vaplic_update_hart_impl(vcpu, (vcpuid_t)i);
+            vaplic_update_hart_line(vcpu, (vcpuid_t)i);
         }
     } else if ((uint16_t)vhart_index < vaplic->idc_num) {
-        vaplic_update_hart_impl(vcpu, (vcpuid_t)vhart_index);
+        vaplic_update_hart_line(vcpu, (vcpuid_t)vhart_index);
+    }
+}
+
+#elif (IRQC == AIA)
+
+/**
+ * @brief Returns the target eeid of a given interrupt
+ *
+ * @param vcpu virtual cpu
+ * @param intp_id interrupt ID
+ * @return uint32_t eeid of the given interrupt
+ */
+static inline uint32_t vaplic_get_eeid(struct vcpu* vcpu, irqid_t intp_id)
+{
+    return vaplic_get_target(vcpu, intp_id) & APLIC_TARGET_EEID_MASK;
+}
+
+static void vaplic_forward_by_msi(struct vcpu* vcpu, irqid_t irq_id)
+{
+    // This function assumes domain is enabled
+
+    bool irq_pend = vaplic_get_pend(vcpu, irq_id);
+    bool irq_enbl = vaplic_get_enbl(vcpu, irq_id);
+
+    if (irq_enbl && irq_pend) {
+        vcpuid_t hart_index = vaplic_get_hart_index(vcpu, irq_id);
+        uint32_t eeid = vaplic_get_eeid(vcpu, irq_id);
+        struct vcpu* target_vcpu = vcpu;
+        if (vcpu->id != hart_index) {
+            target_vcpu = vm_get_vcpu(vcpu->vm, hart_index);
+        }
+
+        imsic_send_guest_msi(target_vcpu->phys_id, eeid);
+
+        CLR_INTP_REG(vcpu->vm->arch.vaplic.ip, irq_id);
     }
 }
 
 /**
- * @brief Processes an incoming event.
+ * @brief Triggers the hart/harts interrupt line update.
  *
- * @param event the event id
- * @param data
+ * @param vcpu virtual cpu
+ * @param vhart_index ignored - this parameter is only used in the implementation
+ * for when imsics are not present to identify the IDC to which access triggered the call
  */
-static void vaplic_ipi_handler(uint32_t event, uint64_t data)
+static void vaplic_update_hart(struct vcpu* vcpu, size_t vhart_index, irqid_t irq_id)
 {
-    switch (event) {
-        case UPDATE_HART_LINE:
-            vaplic_update_hart(cpu()->vcpu, (size_t)data);
-            break;
-        default:
-            WARNING("Unknown VAPLIC IPI event");
-            break;
+    UNUSED_ARG(vhart_index);
+
+    bool domain_enbl = (vaplic_get_domaincfg(vcpu) & APLIC_DOMAINCFG_IE) != 0;
+
+    if (domain_enbl) {
+        if (irq_id == INVALID_IRQID) {
+            for (irqid_t i = 1; i < APLIC_MAX_INTERRUPTS; i++) {
+                vaplic_forward_by_msi(vcpu, i);
+            }
+        } else {
+            vaplic_forward_by_msi(vcpu, irq_id);
+        }
     }
 }
+#endif /* (IRQC == AIA) */
 
 /**
  * @brief Write to domaincfg register a new value.
@@ -631,7 +646,7 @@ static void vaplic_set_domaincfg(struct vcpu* vcpu, uint32_t new_val)
         new_val &= ~APLIC_DOMAINCFG_DM;
     }
     vaplic->domaincfg = new_val | APLIC_DOMAINCFG_RO80;
-    vaplic_update_hart(vcpu, UPDATE_ALL_HARTS);
+    vaplic_update_hart(vcpu, UPDATE_ALL_HARTS, INVALID_IRQID);
     spin_unlock(&vaplic->lock);
 }
 
@@ -710,7 +725,7 @@ static void vaplic_set_sourcecfg(struct vcpu* vcpu, irqid_t intp_id, uint32_t ne
         } else {
             SET_INTP_REG(vaplic->active, intp_id);
         }
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, intp_id));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, intp_id), intp_id);
     }
     spin_unlock(&vaplic->lock);
 }
@@ -754,7 +769,8 @@ static void vaplic_set_setip(struct vcpu* vcpu, size_t reg, uint32_t new_val)
         for (size_t i = (reg * APLIC_NUM_INTP_PER_REG);
              i < (reg * APLIC_NUM_INTP_PER_REG) + APLIC_NUM_INTP_PER_REG; i++) {
             if (!!bit32_get(update_intps, i % 32)) {
-                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, (irqid_t)i));
+                irqid_t irq_id = (irqid_t)i;
+                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, irq_id), irq_id);
             }
         }
     }
@@ -773,7 +789,7 @@ static void vaplic_set_setipnum(struct vcpu* vcpu, uint32_t new_val)
 
     spin_lock(&vaplic->lock);
     if (vaplic_set_pend(vcpu, new_val)) {
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val), new_val);
     }
     spin_unlock(&vaplic->lock);
 }
@@ -802,7 +818,8 @@ static void vaplic_set_in_clrip(struct vcpu* vcpu, size_t reg, uint32_t new_val)
         for (size_t i = (reg * APLIC_NUM_INTP_PER_REG);
              i < (reg * APLIC_NUM_INTP_PER_REG) + APLIC_NUM_INTP_PER_REG; i++) {
             if (!!bit32_get(update_intps, i % 32)) {
-                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, (irqid_t)i));
+                irqid_t irq_id = (irqid_t)i;
+                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, irq_id), irq_id);
             }
         }
     }
@@ -845,7 +862,7 @@ static void vaplic_set_clripnum(struct vcpu* vcpu, uint32_t new_val)
         } else {
             CLR_INTP_REG(vaplic->ip, new_val);
         }
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val), new_val);
     }
     spin_unlock(&vaplic->lock);
 }
@@ -890,7 +907,8 @@ static void vaplic_set_setie(struct vcpu* vcpu, size_t reg, uint32_t new_val)
         for (size_t i = (reg * APLIC_NUM_INTP_PER_REG);
              i < (reg * APLIC_NUM_INTP_PER_REG) + APLIC_NUM_INTP_PER_REG; i++) {
             if (!!bit32_get(update_intps, i % 32)) {
-                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, (irqid_t)i));
+                irqid_t irq_id = (irqid_t)i;
+                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, irq_id), irq_id);
             }
         }
     }
@@ -913,7 +931,7 @@ static void vaplic_set_setienum(struct vcpu* vcpu, uint32_t new_val)
             aplic_set_enbl(new_val);
         }
         SET_INTP_REG(vaplic->ie, new_val);
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val), new_val);
     }
     spin_unlock(&vaplic->lock);
 }
@@ -940,7 +958,8 @@ static void vaplic_set_clrie(struct vcpu* vcpu, size_t reg, uint32_t new_val)
         for (size_t i = (reg * APLIC_NUM_INTP_PER_REG);
              i < (reg * APLIC_NUM_INTP_PER_REG) + APLIC_NUM_INTP_PER_REG; i++) {
             if (!!bit32_get(update_intps, i % 32)) {
-                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, (irqid_t)i));
+                irqid_t irq_id = (irqid_t)i;
+                vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, irq_id), irq_id);
             }
         }
     }
@@ -963,7 +982,7 @@ static void vaplic_set_clrienum(struct vcpu* vcpu, uint32_t new_val)
             aplic_clr_enbl(new_val);
         }
         CLR_INTP_REG(vaplic->ie, new_val);
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, new_val), new_val);
     }
     spin_unlock(&vaplic->lock);
 }
@@ -1027,9 +1046,9 @@ static void vaplic_set_target(struct vcpu* vcpu, irqid_t intp_id, uint32_t new_v
         }
 
         if (prev_hart_index != hart_index) {
-            vaplic_update_hart(vcpu, prev_hart_index);
+            vaplic_update_hart(vcpu, prev_hart_index, intp_id);
         }
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, intp_id));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, intp_id), intp_id);
     }
     spin_unlock(&vaplic->lock);
 }
@@ -1238,7 +1257,7 @@ void vaplic_inject(struct vcpu* vcpu, irqid_t intp_id)
     spin_lock(&vaplic->lock);
     /** If the intp was successfully injected, update the heart line. */
     if (vaplic_set_pend(vcpu, intp_id)) {
-        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, intp_id));
+        vaplic_update_hart(vcpu, vaplic_get_hart_index(vcpu, intp_id), intp_id);
     }
     spin_unlock(&vaplic->lock);
 }


### PR DESCRIPTION
This PR refactors APLIC MSI injection in IMSIC guest interrupt files and fixes two issues:

1. The previous implementation assumed that MSI injection into a guest interrupt file always targeted the local vCPU. If the target vCPU was remote, it sent a CPU message to the target core so the MSI could be injected locally. However, the IMSIC MMIO interface allows a CPU to inject an MSI directly into a *remote* (i.e., different core) guest IMSIC via its MMIO interface. Supporting this requires:

     - Mapping guest interrupt files in the hypervisor.
     - Introducing a function that injects an MSI by writing to the appropriate guest interrupt file MMIO interface based on the target CPU and its assigned guest interrupt file.
  
     Alternatively, local vCPU injection could still use the AIA CSRs (as before). To simplify the code, this optimization is intentionally avoided for now. Future work may evaluate whether MMIO-based injection is sufficiently costly to justify reintroducing this optimization.

2. On updates to APLIC registers, the previous implementation iterated over all APLIC interrupts to determine whether an MSI should be forwarded to a vCPU. In most cases (e.g., enabling a single interrupt), only one interrupt needs to be considered. This PR addresses the issue by adding a third argument to `vaplic_update_hart`, indicating whether the call was triggered by a single interrupt state update. If the interrupt ID is invalid (e.g., when triggered by a global vAPLIC control update), the logic falls back to scanning all interrupts for forwarding.