### PR TITLE
fix(arch/armv8): add explicit casts to fix size_t to uint32_t conversion warnings

### DIFF
--- a/src/arch/armv8/armv8-a/smmuv2.c
+++ b/src/arch/armv8/armv8-a/smmuv2.c
@@ -229,7 +229,7 @@ void smmu_write_ctxbnk(size_t ctx_id, paddr_t root_pt, asid_t vm_id)
         tcr |= SMMUV2_TCR_TG0_4K;
         tcr |= SMMUV2_TCR_ORGN0_WB_RA_WA;
         tcr |= SMMUV2_TCR_IRGN0_WB_RA_WA;
-        tcr |= SMMUV2_TCR_T0SZ(t0sz);
+        tcr |= (uint32_t)SMMUV2_TCR_T0SZ(t0sz);
         tcr |= SMMUV2_TCR_SH0_IS;
         tcr |= ((parange_table[parange] < 44) ? SMMUV2_TCR_SL0_1 : SMMUV2_TCR_SL0_0);
         smmu.hw.cntxt[ctx_id].TCR = tcr;
@@ -338,7 +338,7 @@ void smmu_write_s2c(size_t sme, size_t ctx_id)
 
         s2cr = S2CR_CLEAR(s2cr);
         s2cr |= S2CR_DFLT;
-        s2cr |= ctx_id & S2CR_CBNDX_MASK;
+        s2cr |= (uint32_t)(ctx_id & S2CR_CBNDX_MASK);
 
         smmu.hw.glbl_rs0->S2CR[sme] = s2cr;
     }

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -324,9 +324,9 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
     vm->arch.vgicd.CTLR = 0;
     size_t vtyper_itln = vgic_get_itln(vgic_dscrp);
     vm->arch.vgicd.int_num = 32 * (vtyper_itln + 1);
-    vm->arch.vgicd.TYPER = ((vtyper_itln << GICD_TYPER_ITLN_OFF) & GICD_TYPER_ITLN_MSK) |
+    vm->arch.vgicd.TYPER = (uint32_t)(((vtyper_itln << GICD_TYPER_ITLN_OFF) & GICD_TYPER_ITLN_MSK) |
         (((vm->cpu_num - 1) << GICD_TYPER_CPUNUM_OFF) & GICD_TYPER_CPUNUM_MSK) |
-        (((10 - 1) << GICD_TYPER_IDBITS_OFF) & GICD_TYPER_IDBITS_MSK);
+        (((10 - 1) << GICD_TYPER_IDBITS_OFF) & GICD_TYPER_IDBITS_MSK));
     vm->arch.vgicd.IIDR = gicd->IIDR;
     vm->arch.vgicd.lock = SPINLOCK_INITVAL;
 


### PR DESCRIPTION
The -Werror=conversion flag causes build failures due to implicit narrowing from size_t (64-bit) to uint32_t (32-bit) in smmuv2 and vgicv3 code. Add explicit (uint32_t) casts where the narrowing is intentional and safe.