### PR TITLE
fix(typos): correct "unkown" typos in log messages

### DIFF
--- a/src/arch/armv8/armv8-a/psci.c
+++ b/src/arch/armv8/armv8-a/psci.c
@@ -70,7 +70,7 @@ void psci_wake(uint32_t handler_id)
     if (handler_id < PSCI_WAKEUP_NUM) {
         psci_wake_handlers[handler_id]();
     } else {
-        ERROR("unkown reason for cpu wake up");
+        ERROR("unknown reason for cpu wake up");
     }
 }
 

--- a/src/arch/armv8/psci.c
+++ b/src/arch/armv8/psci.c
@@ -217,7 +217,7 @@ int32_t psci_smc_handler(uint32_t smc_fid, unsigned long x1, unsigned long x2, u
             break;
 
         default:
-            INFO("unkown psci smc_fid 0x%lx", smc_fid);
+            INFO("unknown psci smc_fid 0x%lx", smc_fid);
     }
 
     return ret;

--- a/src/arch/riscv/interrupts.c
+++ b/src/arch/riscv/interrupts.c
@@ -119,7 +119,7 @@ void interrupts_arch_handle(void)
             irqc_handle();
             break;
         default:
-            WARNING("unkown interrupt");
+            WARNING("unknown interrupt");
             break;
     }
 }

--- a/src/arch/riscv/sync_exceptions.c
+++ b/src/arch/riscv/sync_exceptions.c
@@ -149,7 +149,7 @@ void sync_exception_handler(void)
     if (_scause < sync_handler_table_size && sync_handler_table[_scause]) {
         pc_step = sync_handler_table[_scause]();
     } else {
-        ERROR("unkown synchronous exception (%d)", _scause);
+        ERROR("unknown synchronous exception (%d)", _scause);
     }
 
     vcpu_writepc(cpu()->vcpu, vcpu_readpc(cpu()->vcpu) + pc_step);

--- a/src/core/mpu/mem.c
+++ b/src/core/mpu/mem.c
@@ -465,7 +465,7 @@ void mem_handle_broadcast_region(uint32_t event, uint64_t data)
         } else {
             struct addr_space* vm_as = &cpu()->vcpu->vm->as;
             if (vm_as->id != sh_reg->asid) {
-                ERROR("Received shared region for unkown vm address space.");
+                ERROR("Received shared region for unknown vm address space.");
             }
             as = vm_as;
         }


### PR DESCRIPTION
Replace misspelled "unkown" with "unknown".