### PR TITLE
Allow config-specific and out-ot-tree sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,9 +293,9 @@ ifneq ($(build_targets),)
 .PHONY: all
 all: $(targets-y)
 
-$(bin_dir)/$(PROJECT_NAME).elf: $(gens) $(objs-y) $(ld_script_temp)
+$(bin_dir)/$(PROJECT_NAME).elf: $(gens) $(objs-y) $(extra-objs-y) $(ld_script_temp)
 	@echo "Linking			$(patsubst $(cur_dir)/%,%, $@)"
-	@$(ld) $(LDFLAGS) -T$(ld_script_temp) $(objs-y) -o $@
+	@$(ld) $(LDFLAGS) -T$(ld_script_temp) $(objs-y) $(extra-objs-y) -o $@
 	@$(objdump) -S --wide $@ > $(basename $@).asm
 	@$(readelf) -a --wide $@ > $@.txt
 


### PR DESCRIPTION
This PR supersedes #313. It allows for a configuration to add custom code by pluging-in to the build systems with the `config.mk` and `objects.mk` files in the specified configuration directory. Furthermore it allows for these files to include fully out-of-tree sources, headers or object files by appending to the `config-objs-y`, `inc_dirs`, or `extra-objs-y` list variables, respectively. 

The main use case for this is to include third-party or vendor BSP code that is used to bring up and configure the platform and which is often generated by vendor SDKs and are too configuration-specific or too complex to include directly in Bao or for integrator to develop from scratch.