### PR TITLE
fix(riscv): modify rv32 virtual address space layout

### DIFF
--- a/src/arch/riscv/inc/arch/bao.h
+++ b/src/arch/riscv/inc/arch/bao.h
@@ -29,14 +29,18 @@
 #define BAO_VM_BASE  (0xffffffe000000000)
 #define BAO_VAS_TOP  (0xfffffff000000000)
 #else
-// Because sv32 only lowest level only supports 4MiB pages, this should be enough for each section
-// otherwise we need allow for N shared PTEs for each section. For now, it seems to suffice. We also
-// are assuming, for now that all available physical memory resides in 0x0 - 0xefffffff of virtual
-// memory. Otherwise we need to implement a "highmem"-like mechanism.
+/**
+ * When using sv32 only the lowest level supports 4MiB pages. This should be
+ * enough for the shared regions, while the private region is left with 256 MiB.
+ * For now, it seems to suffice. Otherwise, we need allow for N shared PTEs for
+ * the shared sections. We are also assuming, for now, that all available
+ * physical memory resides in 0x0 - 0xefffffff of virtual memory. Otherwise we
+ * need to implement a "highmem"-like mechanism.
+ */
 #define BAO_VAS_BASE (0xc0000000)
-#define BAO_CPU_BASE (0xcf400000)
-#define BAO_VM_BASE  (0xcf800000)
-#define BAO_VAS_TOP  (0xcfc00000)
+#define BAO_CPU_BASE (0xc0400000)
+#define BAO_VM_BASE  (0xe0400000)
+#define BAO_VAS_TOP  (0xe0800000)
 #endif
 
 #define PAGE_SIZE        (0x1000)


### PR DESCRIPTION
The previous RV32 address space layout had two issues:

1. The shared global image starting in BAO_VAS_BASE and ending in BAO_CPU_BASE was much larger than the 4 MB region actually shared by duplicating the L0 page-table entry for that region. This meant that if mapping outside the first 4MB of the region, the mappings were not actually shared by private to the cpu mapping them.
2. The private CPU region starting at BAO_CPU_BASE and ending at BAO_VM_BASE was only 4 MB which made impossible to create private mappings larger than that size.

This PR fixes the first issue by limiting the shared region only to 4MB and the second by increasing significantly the size of the private region. However, this means that large mappings are not possible globally. In principle that should not be necessary. If required in the future, one need to allocate multiple L1 page tables in root_pt.S, and replicate multiple entries in each CPU's L0 table. This has the downside that many more page tables might need to be allocated by default, possible wasting memory if the shared mappings are not used, and increasing boot time as all those tables must be zeroes at boot time. For example for a 64 MB shared region, this means 16 L1 tables must be shared totalling 64 KB, instead of just the 4 used at this time.