### PR TITLE
fix(core): remove built-in image mention from mem reserve comment

### DIFF
--- a/src/core/mem.c
+++ b/src/core/mem.c
@@ -325,13 +325,12 @@ static void mem_init_reserved(void)
     for (size_t i = 0; i < config.vmlist_size; i++) {
         struct vm_config* vm_cfg = &config.vmlist[i];
 
-        // If the vm image is already built-in the hypervisor image or is part
-        // of a statically allocated region of the same vm, we defer the
-        // reservation of this memory to when we reserve the physical region
-        // below. Note that this not allow partial overlaps. If the image must
-        // be entirely inside a statically allocated region, or completely
-        // outside of it. This avoid overcamplicating the reservation logic
-        // while still covering all the useful use cases.
+        // If the vm image is part of a statically allocated region of the same
+        // vm, we defer the reservation of this memory to when we reserve the
+        // physical region below. Note that this not allow partial overlaps. If
+        // the image must be entirely inside a statically allocated region, or
+        // completely outside of it. This avoid overcamplicating the
+        // reservation logic while still covering all the useful use cases.
         if (mem_vm_img_in_phys_rgn(vm_cfg)) {
             vm_cfg->image.reserved = true;
         } else {


### PR DESCRIPTION
The comment in mem_init_reserved() described two conditions under which memory reservation is deferred: when the VM image is built into the hypervisor image, or when it is part of a statically allocated region.

However, the deferral logic (mem_vm_img_in_phys_rgn) only covers the latter case. Remove the reference to built-in images from the comment to accurately reflect the actual behavior.