### PR TITLE
armv8: add MPIDR table support and extend affinity handling for newer CPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,9 @@ ifeq ($(arch_mem_prot),mpu)
 	build_macros+=-DMEM_PROT_MPU
 endif
 ifeq ($(plat_mem),non_unified)
+	ifeq ($(ARCH),aarch64)
+		$(error AArch64 with non_unified memory is not supported)
+	endif
 	build_macros+=-DMEM_NON_UNIFIED
 endif
 ifeq ($(phys_irqs_only),y)

--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -238,6 +238,7 @@ set_loop:
  * x5 - current entry
  * x6 - index in mpidr_table->table[]
  * x7 - original MPIDR (saved for MT bit check)
+ * x8 - temporary scratch register
  */
 .global mpidr_to_cpu_id
 mpidr_to_cpu_id:

--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -47,6 +47,7 @@ _reset_handler:
 
 	mrs  x0, MPIDR_EL1
 	adrp x1, _image_start
+    bl mpidr_to_cpu_id
 
 	adr x2, img_addr
     str x1, [x2] // store image load address in img_addr
@@ -66,7 +67,9 @@ _reset_handler:
 	 */
 
 	lsr x3, x0, #8
-	and x3, x3, 0xff
+    and x0, x0, #0xFF
+	and x3, x3, #0xFF
+
 	adr x4, platform
 	ldr x4, [x4, PLAT_ARCH_OFF+PLAT_ARCH_CLUSTERS_OFF+PLAT_CLUSTERS_CORES_NUM_OFF]
 	ldr x5, =BAO_VAS_BASE
@@ -224,3 +227,72 @@ set_loop:
 	cmp x5, x3 // last way reached yet?
 	ble way_loop // if not, iterate way_loop
 	ret
+
+/*
+ * Registers
+ * x0 - MPIDR_EL1 input / output: [15:8] cluster ID, [7:0] core ID
+ * x1 - image base
+ * x2 - mpidr_table ptr
+ * x3 - cpu_num
+ * x4 - iterator
+ * x5 - current entry
+ * x6 - index in mpidr_table->table[]
+ * x7 - original MPIDR (saved for MT bit check)
+ * x8 - temporary scratch register
+ */
+.global mpidr_to_cpu_id
+mpidr_to_cpu_id:
+    mov x7, x0                        /* save original MPIDR for MT check */
+    adr x2, platform
+    ldr x2, [x2, PLAT_ARCH_OFF+PLAT_ARCH_MPIDR_TABLE_OFF+PLAT_MPIDR_TABLE_OFF]
+    cbz x2, no_table
+    /* Relocate pointer */
+    ldr x5, =BAO_VAS_BASE
+    sub x2, x2, x5
+    add x2, x2, x1
+    mov x4, x2
+    adr x3, platform
+    ldr x3, [x3, PLAT_CPUNUM_OFF]
+    and x0, x0, #0x00FFFFFF           /* mask MPIDR input once before the loop */
+    mov x6, #0
+1:  /* table scan */
+    ldr x5, [x4]
+    and x5, x5, #0x00FFFFFF           /* mask table entry */
+    cmp x5, x0
+    b.eq found
+    /* Increment iterator */
+    add x4, x4, #8
+    /* Increment index in the table */
+    add x6, x6, #1
+    /* Loop until the end */
+    cmp x6, x3
+    b.lt 1b
+    /* not found */
+    mov x0, #0xff
+    ret
+found:
+    tbz x7, #24, found_no_mt
+    /* MT == 1: Aff2=cluster, Aff1=core */
+    ubfx x8, x5, #16, #8
+    ubfx x0, x5, #8,  #8
+    orr  x0, x0, x8, lsl #8
+    ret
+found_no_mt:
+    /* MT == 0: Aff1=cluster, Aff0=core */
+    ubfx x8, x5, #8, #8
+    ubfx x0, x5, #0, #8
+    orr  x0, x0, x8, lsl #8
+    ret
+no_table:
+    tbz x7, #24, no_mt
+    /* MT == 1: Aff2=cluster, Aff1=core */
+    ubfx x8, x7, #16, #8
+    ubfx x0, x7, #8,  #8
+    orr  x0, x0, x8, lsl #8
+    ret
+no_mt:
+    /* MT == 0: Aff1=cluster, Aff0=core */
+    ubfx x8, x7, #8, #8
+    ubfx x0, x7, #0, #8
+    orr  x0, x0, x8, lsl #8
+    ret

--- a/src/arch/armv8/aarch64/boot.S
+++ b/src/arch/armv8/aarch64/boot.S
@@ -47,6 +47,7 @@ _reset_handler:
 
 	mrs  x0, MPIDR_EL1
 	adrp x1, _image_start
+    bl mpidr_to_cpu_id
 
 	adr x2, img_addr
     str x1, [x2] // store image load address in img_addr
@@ -66,7 +67,9 @@ _reset_handler:
 	 */
 
 	lsr x3, x0, #8
-	and x3, x3, 0xff
+    and x0, x0, #0xFF
+	and x3, x3, #0xFF
+
 	adr x4, platform
 	ldr x4, [x4, PLAT_ARCH_OFF+PLAT_ARCH_CLUSTERS_OFF+PLAT_CLUSTERS_CORES_NUM_OFF]
 	ldr x5, =BAO_VAS_BASE
@@ -224,3 +227,71 @@ set_loop:
 	cmp x5, x3 // last way reached yet?
 	ble way_loop // if not, iterate way_loop
 	ret
+
+/*
+ * Registers
+ * x0 - MPIDR_EL1 input / output: [15:8] cluster ID, [7:0] core ID
+ * x1 - image base
+ * x2 - mpidr_table ptr
+ * x3 - cpu_num
+ * x4 - iterator
+ * x5 - current entry
+ * x6 - index in mpidr_table->table[]
+ * x7 - original MPIDR (saved for MT bit check)
+ */
+.global mpidr_to_cpu_id
+mpidr_to_cpu_id:
+    mov x7, x0                        /* save original MPIDR for MT check */
+    adr x2, platform
+    ldr x2, [x2, PLAT_ARCH_OFF+PLAT_ARCH_MPIDR_TABLE_OFF+PLAT_MPIDR_TABLE_OFF]
+    cbz x2, no_table
+    /* Relocate pointer */
+    ldr x5, =BAO_VAS_BASE
+    sub x2, x2, x5
+    add x2, x2, x1
+    mov x4, x2
+    adr x3, platform
+    ldr x3, [x3, PLAT_CPUNUM_OFF]
+    and x0, x0, #0x00FFFFFF           /* mask MPIDR input once before the loop */
+    mov x6, #0
+1:  /* table scan */
+    ldr x5, [x4]
+    and x5, x5, #0x00FFFFFF           /* mask table entry */
+    cmp x5, x0
+    b.eq found
+    /* Increment iterator */
+    add x4, x4, #8
+    /* Increment index in the table */
+    add x6, x6, #1
+    /* Loop until the end */
+    cmp x6, x3
+    b.lt 1b
+    /* not found */
+    mov x0, #0xff
+    ret
+found:
+    tbz x7, #24, found_no_mt
+    /* MT == 1: Aff2=cluster, Aff1=core */
+    ubfx x8, x5, #16, #8
+    ubfx x0, x5, #8,  #8
+    orr  x0, x0, x8, lsl #8
+    ret
+found_no_mt:
+    /* MT == 0: Aff1=cluster, Aff0=core */
+    ubfx x8, x5, #8, #8
+    ubfx x0, x5, #0, #8
+    orr  x0, x0, x8, lsl #8
+    ret
+no_table:
+    tbz x7, #24, no_mt
+    /* MT == 1: Aff2=cluster, Aff1=core */
+    ubfx x8, x7, #16, #8
+    ubfx x0, x7, #8,  #8
+    orr  x0, x0, x8, lsl #8
+    ret
+no_mt:
+    /* MT == 0: Aff1=cluster, Aff0=core */
+    ubfx x8, x7, #8, #8
+    ubfx x0, x7, #0, #8
+    orr  x0, x0, x8, lsl #8
+    ret

--- a/src/arch/armv8/asm_defs.c
+++ b/src/arch/armv8/asm_defs.c
@@ -41,6 +41,8 @@ __attribute__((used)) static void platform_defines(void)
     DEFINE_OFFSET(PLAT_CPUNUM_OFF, struct platform, cpu_num);
     DEFINE_OFFSET(PLAT_ARCH_OFF, struct platform, arch);
     DEFINE_OFFSET(PLAT_ARCH_CLUSTERS_OFF, struct arch_platform, clusters);
+    DEFINE_OFFSET(PLAT_ARCH_MPIDR_TABLE_OFF, struct arch_platform, mpidr_table);
     DEFINE_OFFSET(PLAT_CLUSTERS_CORES_NUM_OFF, struct clusters, core_num);
     DEFINE_SIZE(PLAT_CLUSTERS_CORES_NUM_SIZE, ((struct clusters*)NULL)->core_num[0]);
+    DEFINE_OFFSET(PLAT_MPIDR_TABLE_OFF, struct mpidr_table, table);
 }

--- a/src/arch/armv8/gicv3.c
+++ b/src/arch/armv8/gicv3.c
@@ -218,13 +218,20 @@ void gicd_set_route(irqid_t int_id, uint64_t route)
 
 void gic_send_sgi(cpuid_t cpu_target, irqid_t sgi_num)
 {
-    if (sgi_num < GIC_MAX_SGIS) {
-        unsigned long mpidr = cpu_id_to_mpidr(cpu_target) & MPIDR_AFF_MSK;
-        /* We only support two affinity levels */
-        uint64_t sgi = (MPIDR_AFF_LVL(mpidr, 1) << ICC_SGIR_AFF1_OFFSET) |
-            (1UL << MPIDR_AFF_LVL(mpidr, 0)) | (sgi_num << ICC_SGIR_SGIINTID_OFF);
-        sysreg_icc_sgi1r_el1_write(sgi);
+    if (sgi_num >= GIC_MAX_SGIS) {
+        return;
     }
+
+    uint64_t mpidr = cpu_id_to_mpidr(cpu_target);
+
+    uint64_t aff0 = MPIDR_AFF_LVL(mpidr, 0);
+    uint64_t aff1 = MPIDR_AFF_LVL(mpidr, 1);
+    uint64_t aff2 = MPIDR_AFF_LVL(mpidr, 2);
+
+    uint64_t sgi = (aff2 << ICC_SGIR_AFF2_OFFSET) | (aff1 << ICC_SGIR_AFF1_OFFSET) |
+        ((uint64_t)sgi_num << ICC_SGIR_SGIINTID_OFF) | (1UL << aff0);
+
+    sysreg_icc_sgi1r_el1_write(sgi);
 }
 
 void gic_set_prio(irqid_t int_id, uint8_t prio)

--- a/src/arch/armv8/inc/arch/gic.h
+++ b/src/arch/armv8/inc/arch/gic.h
@@ -223,6 +223,7 @@ struct gicr_hw {
 #define ICC_SGIR_TRGLSTFLT_MSK   BIT64_MASK(ICC_SGIR_TRGLSTFLT_OFF, ICC_SGIR_TRGLSTFLT_LEN)
 #define ICC_SGIR_TRGLSTFLT(sgir) bit64_extract(sgir, ICC_SGIR_TRGLSTFLT_OFF, ICC_SGIR_TRGLSTFLT_LEN)
 #define ICC_SGIR_AFF1_OFFSET     (16)
+#define ICC_SGIR_AFF2_OFFSET     (32)
 
 #define ICC_SRE_ENB_BIT          (0x8)
 #define ICC_SRE_DIB_BIT          (0x4)

--- a/src/arch/armv8/inc/arch/platform.h
+++ b/src/arch/armv8/inc/arch/platform.h
@@ -39,6 +39,10 @@ struct arch_platform {
         size_t num;
         size_t* core_num;
     } clusters;
+
+    struct mpidr_table {
+        unsigned long* table;
+    } mpidr_table;
 };
 
 struct platform;

--- a/src/arch/armv8/inc/arch/sysregs.h
+++ b/src/arch/armv8/inc/arch/sysregs.h
@@ -29,7 +29,8 @@
 #define MPIDR_RES0_MSK            ~(0x1ful << 25)
 #define MPIDR_AFFINITY_BITS       (8)
 #define MPIDR_U_BIT               (1UL << 30)
-#define MPIDR_AFF_MSK             (0xffff) // we are only supporting 2 affinity levels
+#define MPIDR_MT_BIT              (1UL << 24)
+#define MPIDR_AFF_MSK             (0xffffff) // we are only supporting 3 affinity levels
 #define MPIDR_AFF_LVL(MPIDR, LVL) (((MPIDR) >> (8 * (LVL))) & 0xff)
 
 /* MIDR_EL1 - Main ID Register */

--- a/src/arch/armv8/platform.c
+++ b/src/arch/armv8/platform.c
@@ -63,7 +63,6 @@ unsigned long platform_arch_cpuid_to_mpidr(const struct platform* plat, cpuid_t 
     }
 
 done:
-
     mpidr |= MPIDR_RES1;
 
     if (plat->cpu_num == 1) {

--- a/src/arch/armv8/platform.c
+++ b/src/arch/armv8/platform.c
@@ -8,36 +8,70 @@
 
 unsigned long platform_arch_cpuid_to_mpidr(const struct platform* plat, cpuid_t cpuid)
 {
-    if (cpuid > plat->cpu_num) {
-        return ~(~MPIDR_RES1 & MPIDR_RES0_MSK); // return an invlid mpidr by inverting res bits
+    if (cpuid >= plat->cpu_num) {
+        return ~(~MPIDR_RES1 & MPIDR_RES0_MSK);
     }
 
     unsigned long mpidr = 0;
-    bool found = false;
+
+    /* Prefer MPIDR table if available */
+    if (plat->arch.mpidr_table.table != NULL) {
+        mpidr = plat->arch.mpidr_table.table[cpuid];
+
+        mpidr |= MPIDR_RES1;
+
+        if (plat->cpu_num == 1) {
+            mpidr |= MPIDR_U_BIT;
+        }
+
+        return mpidr;
+    }
+
+    /* SoCs use a uniform topology; use current CPU MT bit */
+    unsigned long cur_mpidr = sysreg_mpidr_el1_read();
+    bool has_mt = (cur_mpidr & MPIDR_MT_BIT) != 0;
+
+    /* Use cluster topology if available */
     if (plat->arch.clusters.num > 0) {
-        for (size_t i = 0, j = 0; i < plat->arch.clusters.num; i++) {
-            if (cpuid < (j + plat->arch.clusters.core_num[i])) {
-                mpidr = (i << 8) | ((cpuid - j) & 0xff);
-                found = true;
-                break;
+        size_t base = 0;
+
+        for (size_t cluster = 0; cluster < plat->arch.clusters.num; cluster++) {
+            size_t cores = plat->arch.clusters.core_num[cluster];
+
+            if (cpuid < base + cores) {
+                unsigned long core = cpuid - base;
+
+                if (has_mt) {
+                    mpidr = (cluster << 16) | (core << 8);
+                } else {
+                    mpidr = (cluster << 8) | (core & 0xff);
+                }
+
+                goto done;
             }
 
-            j += plat->arch.clusters.core_num[i];
+            base += cores;
         }
 
-        if (!found) {
-            ERROR("failed cpuid to mpidr translation\n");
-        }
+        ERROR("failed cpuid to mpidr translation\n");
+    }
+
+    if (has_mt) {
+        mpidr = (cpuid << 8);
     } else {
-        /**
-         * No cluster information in configuration. Assume a singl cluster.
-         */
         mpidr = cpuid;
     }
 
+done:
+
     mpidr |= MPIDR_RES1;
+
     if (plat->cpu_num == 1) {
         mpidr |= MPIDR_U_BIT;
+    }
+
+    if (has_mt) {
+        mpidr |= MPIDR_MT_BIT;
     }
 
     return mpidr;

--- a/src/arch/armv8/platform.c
+++ b/src/arch/armv8/platform.c
@@ -8,36 +8,70 @@
 
 unsigned long platform_arch_cpuid_to_mpidr(const struct platform* plat, cpuid_t cpuid)
 {
-    if (cpuid > plat->cpu_num) {
-        return ~(~MPIDR_RES1 & MPIDR_RES0_MSK); // return an invlid mpidr by inverting res bits
+    if (cpuid >= plat->cpu_num) {
+        return ~(~MPIDR_RES1 & MPIDR_RES0_MSK);
     }
 
     unsigned long mpidr = 0;
-    bool found = false;
+
+    /* Prefer MPIDR table if available */
+    if (plat->arch.mpidr_table.table != NULL) {
+        mpidr = plat->arch.mpidr_table.table[cpuid];
+
+        mpidr |= MPIDR_RES1;
+
+        if (plat->cpu_num == 1) {
+            mpidr |= MPIDR_U_BIT;
+        }
+
+        return mpidr;
+    }
+
+    /* SoCs use a uniform topology; use current CPU MT bit */
+    unsigned long cur_mpidr = sysreg_mpidr_el1_read();
+    bool has_mt = (cur_mpidr & MPIDR_MT_BIT) != 0;
+
+    /* Use cluster topology if available */
     if (plat->arch.clusters.num > 0) {
-        for (size_t i = 0, j = 0; i < plat->arch.clusters.num; i++) {
-            if (cpuid < (j + plat->arch.clusters.core_num[i])) {
-                mpidr = (i << 8) | ((cpuid - j) & 0xff);
+        size_t base = 0;
+        bool found = false;
+
+        for (size_t cluster = 0; cluster < plat->arch.clusters.num; cluster++) {
+            size_t cores = plat->arch.clusters.core_num[cluster];
+
+            if (cpuid < base + cores) {
+                unsigned long core = cpuid - base;
+
+                if (has_mt) {
+                    mpidr = (cluster << 16) | (core << 8);
+                } else {
+                    mpidr = (cluster << 8) | (core & 0xff);
+                }
+
                 found = true;
                 break;
             }
 
-            j += plat->arch.clusters.core_num[i];
+            base += cores;
         }
 
         if (!found) {
             ERROR("failed cpuid to mpidr translation\n");
         }
+    } else if (has_mt) {
+        mpidr = (cpuid << 8);
     } else {
-        /**
-         * No cluster information in configuration. Assume a singl cluster.
-         */
         mpidr = cpuid;
     }
 
     mpidr |= MPIDR_RES1;
+
     if (plat->cpu_num == 1) {
         mpidr |= MPIDR_U_BIT;
+    }
+
+    if (has_mt) {
+        mpidr |= MPIDR_MT_BIT;
     }
 
     return mpidr;


### PR DESCRIPTION
This patch introduces support for newer Arm CPU topologies (e.g. `Cortex-A55`, `A76`, `A78AE`) where CPU identification is not strictly encoded in Aff0 (`MPIDR_EL1[7:0]`) but may instead rely on higher affinity levels such as `Aff1` (`MPIDR_EL1[15:8]`). On these platforms, `Aff0` typically represents thread ID (often 0x0 for single-threaded cores like Cortex-A55), making previous assumptions about CPU ID encoding invalid.

Key changes:
- Add `mpidr_table` support to allow explicit CPU ID <-> MPIDR mappings. This is required for SoCs with non-linear CPU layouts (e.g. Jetson Orin Nano), where CPU IDs do not map sequentially within clusters.
- Introduce `mpidr_to_cpu_id()` in early boot to derive logical CPU IDs from MPIDR values using the platform-provided table when available.
- Extend MPIDR affinity mask handling from 2 to 3 levels (Aff0–Aff2).
- Update GICv3 SGI routing to include Aff2, enabling correct interrupt targeting on multi-level affinity systems.
- Refactor `platform_arch_cpuid_to_mpidr`() to:
  * Prefer mpidr_table when present
  * Fall back to cluster topology
  * Preserve architectural MPIDR bits (RES1, U bit)
- Add required structure fields and offset definitions for the new mpidr_table.