### PR TITLE
ref: remove unused struct addr_space_arch from MPU arch headers

### DIFF
--- a/src/arch/rh850/inc/arch/mem.h
+++ b/src/arch/rh850/inc/arch/mem.h
@@ -43,10 +43,6 @@ typedef union {
     uint32_t raw;
 } mpat_flags_t;
 
-struct addr_space_arch {
-    unsigned long mpu_entry_mask;
-};
-
 typedef mpat_flags_t mem_flags_t;
 
 #define PTE_INVALID ((mem_flags_t){ .e = 0 })

--- a/src/arch/tricore/inc/arch/mem.h
+++ b/src/arch/tricore/inc/arch/mem.h
@@ -17,10 +17,6 @@ typedef union {
     };
 } mem_flags_t;
 
-struct addr_space_arch {
-    EMPTY_STRUCT_FIELDS
-};
-
 #define PTE_FLAGS(w, r, x)       ((mem_flags_t){ .write = (w), .read = (r), .exec = (x) })
 
 #define PTE_INVALID              PTE_FLAGS(0, 0, 0)


### PR DESCRIPTION
`struct addr_space_arch` was defined in `src/arch/tricore/inc/arch/mem.h`
and `src/arch/rh850/inc/arch/mem.h` but is never referenced anywhere in
the codebase. Remove both dead definitions.