### PR TITLE
fix(build): force PHYS_IRQS_ONLY for rh850 and tricore

### DIFF
--- a/src/arch/rh850/arch.mk
+++ b/src/arch/rh850/arch.mk
@@ -17,4 +17,5 @@ arch-asflags+=-mrh850-abi
 arch-asflags+=-m8byte-align
 
 arch_mem_prot:=mpu
+phys_irqs_only:=y
 PAGE_SIZE:=64

--- a/src/arch/tricore/arch.mk
+++ b/src/arch/tricore/arch.mk
@@ -9,6 +9,7 @@ arch-cppflags+=
 arch-ldflags=
 
 arch_mem_prot:=mpu
+phys_irqs_only:=y
 plat_mem:=non_unified
 PAGE_SIZE:=64
 mmio_slave_side_prot:=y


### PR DESCRIPTION
## Summary

- RH850 and TriCore have no virtual interrupt controller; injection writes directly to the physical hardware pending register (`intc_set_pend`/`ir_set_pend`)
- `PHYS_IRQS_ONLY` must always be set for these architectures but was previously left to per-platform configuration, making it easy to accidentally omit
- Force `phys_irqs_only:=y` in `arch.mk` for both architectures, following the same pattern already used for `mmio_slave_side_prot:=y` in TriCore and `arch_mem_prot:=mpu` in both
