### PR TITLE
feat(riscv): add Sstateen extension support

### DIFF
--- a/src/arch/riscv/inc/arch/csrs.h
+++ b/src/arch/riscv/inc/arch/csrs.h
@@ -26,6 +26,11 @@
 /* Sstc Extension */
 #define CSR_VSTIMECMP     0x24D
 #define CSR_VSTIMECMPH    0x25D
+/* Supervisor State Enable (Ssstateen Extension)*/
+#define CSR_SSTATEEN0     0x10C
+#define CSR_SSTATEEN1     0x10D
+#define CSR_SSTATEEN2     0x10E
+#define CSR_SSTATEEN3     0x10F
 
 #define CSR_HSTATUS       0x600
 #define CSR_HEDELEG       0x602
@@ -44,6 +49,15 @@
 /* Hypervisor Configuration */
 #define CSR_HENVCFG       0x60A
 #define CSR_HENVCFGH      0x61A
+/* Hypervisor State Enable (Ssstateen Extension)*/
+#define CSR_HSTATEEN0     0x60C
+#define CSR_HSTATEEN1     0x60D
+#define CSR_HSTATEEN2     0x60E
+#define CSR_HSTATEEN3     0x60F
+#define CSR_HSTATEEN0H    0x61C
+#define CSR_HSTATEEN1H    0x61D
+#define CSR_HSTATEEN2H    0x61E
+#define CSR_HSTATEEN3H    0x61F
 
 #define TOPI_IID_SHIFT    (16)
 
@@ -126,6 +140,10 @@
 #define SIP_STIP           SIE_STIE
 #define SIP_UEIP           SIE_UEIE
 #define SIP_SEIP           SIE_SEIE
+
+#define SSTATEEN_C         (1ULL << 0)
+#define SSTATEEN_FCSR      (1ULL << 1)
+#define SSTATEEN_JVT       (1ULL << 2)
 
 #define HIE_VSSIE          (1UL << 2)
 #define HIE_VSTIE          (1UL << 6)
@@ -236,6 +254,17 @@
 #define HENVCFG_CBIE_FLUSH          (1ULL << HENVCFG_CBIE_OFF)
 #define HENVCFG_CBIE_INV            (3ULL << HENVCFG_CBIE_OFF)
 
+#define HSTATEEN_C                  (1ULL << 0)
+#define HSTATEEN_FCSR               (1ULL << 1)
+#define HSTATEEN_JVT                (1ULL << 2)
+#define HSTATEEN_CTR                (1ULL << 54)
+#define HSTATEEN_CTX                (1ULL << 57)
+#define HSTATEEN_IMSIC              (1ULL << 58)
+#define HSTATEEN_AIA                (1ULL << 59)
+#define HSTATEEN_CSRIND             (1ULL << 60)
+#define HSTATEEN_ENVCFG             (1ULL << 62)
+#define HSTATEEN_SEO                (1ULL << 63)
+
 #define HCOUNTEREN_CY               (1ULL << 0)
 #define HCOUNTEREN_TM               (1ULL << 1)
 #define HCOUNTEREN_IR               (1ULL << 2)
@@ -306,6 +335,10 @@ CSRS_GEN_ACCESSORS(sie)
 CSRS_GEN_ACCESSORS(sip)
 CSRS_GEN_ACCESSORS(satp)
 CSRS_GEN_ACCESSORS(senvcfg)
+CSRS_GEN_ACCESSORS(sstateen0)
+CSRS_GEN_ACCESSORS(sstateen1)
+CSRS_GEN_ACCESSORS(sstateen2)
+CSRS_GEN_ACCESSORS(sstateen3)
 
 CSRS_GEN_ACCESSORS_NAMED(hstatus, CSR_HSTATUS)
 CSRS_GEN_ACCESSORS_NAMED(hgatp, CSR_HGATP)
@@ -336,10 +369,27 @@ CSRS_GEN_ACCESSORS_NAMED(stimecmp, CSR_STIMECMP)
 CSRS_GEN_ACCESSORS_NAMED(vstimecmp, CSR_VSTIMECMP)
 CSRS_GEN_ACCESSORS_NAMED(henvcfg, CSR_HENVCFG)
 CSRS_GEN_ACCESSORS_NAMED(htimedelta, CSR_HTIMEDELTA)
+CSRS_GEN_ACCESSORS_NAMED(hstateen0, CSR_HSTATEEN0)
+CSRS_GEN_ACCESSORS_NAMED(hstateen1, CSR_HSTATEEN1)
+CSRS_GEN_ACCESSORS_NAMED(hstateen2, CSR_HSTATEEN2)
+CSRS_GEN_ACCESSORS_NAMED(hstateen3, CSR_HSTATEEN3)
 #else
 CSRS_GEN_ACCESSORS_NAMED(henvcfgl, CSR_HENVCFG)
 CSRS_GEN_ACCESSORS_NAMED(henvcfgh, CSR_HENVCFGH)
 CSRS_GEN_ACCESSORS_MERGED(henvcfg, henvcfgl, henvcfgh)
+
+CSRS_GEN_ACCESSORS_NAMED(hstateen0l, CSR_HSTATEEN0)
+CSRS_GEN_ACCESSORS_NAMED(hstateen0h, CSR_HSTATEEN0H)
+CSRS_GEN_ACCESSORS_MERGED(hstateen0, hstateen0l, hstateen0h)
+CSRS_GEN_ACCESSORS_NAMED(hstateen1l, CSR_HSTATEEN1)
+CSRS_GEN_ACCESSORS_NAMED(hstateen1h, CSR_HSTATEEN1H)
+CSRS_GEN_ACCESSORS_MERGED(hstateen1, hstateen1l, hstateen1h)
+CSRS_GEN_ACCESSORS_NAMED(hstateen2l, CSR_HSTATEEN2)
+CSRS_GEN_ACCESSORS_NAMED(hstateen2h, CSR_HSTATEEN2H)
+CSRS_GEN_ACCESSORS_MERGED(hstateen2, hstateen2l, hstateen2h)
+CSRS_GEN_ACCESSORS_NAMED(hstateen3l, CSR_HSTATEEN3)
+CSRS_GEN_ACCESSORS_NAMED(hstateen3h, CSR_HSTATEEN3H)
+CSRS_GEN_ACCESSORS_MERGED(hstateen3, hstateen3l, hstateen3h)
 
 CSRS_GEN_ACCESSORS_NAMED(htimedeltal, CSR_HTIMEDELTA)
 CSRS_GEN_ACCESSORS_NAMED(htimedeltah, CSR_HTIMEDELTAH)

--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -45,20 +45,36 @@ void vcpu_arch_reset(struct vcpu* vcpu, vaddr_t entry)
     }
 
     vcpu->regs.sstatus = SSTATUS_SPP_BIT | SSTATUS_FS_DIRTY | SSTATUS_XS_DIRTY;
+
+    if (CPU_HAS_EXTENSION(CPU_EXT_F)) {
+        vcpu->regs.sstatus |= SSTATUS_FS_DIRTY;
+    }
+
     if (CPU_HAS_EXTENSION(CPU_EXT_V)) {
         vcpu->regs.sstatus |= SSTATUS_VS_DIRTY;
     }
+
     vcpu->regs.sepc = entry;
     vcpu->regs.a0 = vcpu->arch.hart_id = vcpu->id;
     vcpu->regs.a1 = 0; // according to sbi it should be the dtb load address
+
+    if (CPU_HAS_EXTENSION(CPU_EXT_SSSTATEEN)) {
+        csrs_sstateen0_write(0);
+    }
 
     csrs_senvcfg_write(0);
     csrs_hcounteren_write(HCOUNTEREN_TM);
     csrs_htimedelta_write(0);
     csrs_vsstatus_write(SSTATUS_SD | SSTATUS_FS_DIRTY | SSTATUS_XS_DIRTY);
+
+    if (CPU_HAS_EXTENSION(CPU_EXT_F)) {
+        csrs_vsstatus_set(SSTATUS_FS_DIRTY);
+    }
+
     if (CPU_HAS_EXTENSION(CPU_EXT_V)) {
         csrs_vsstatus_set(SSTATUS_VS_DIRTY);
     }
+
     csrs_hie_write(0);
     csrs_vstvec_write(0);
     csrs_vsscratch_write(0);

--- a/src/arch/riscv/vmm.c
+++ b/src/arch/riscv/vmm.c
@@ -71,6 +71,120 @@ void vmm_arch_init()
             ERROR("Platform configured to use ZICBOM extensions, but extension not present.\r\n");
         }
     }
+
+    /**
+     * Configure the State Enable mechanism (Ssstateen).
+     *
+     * State enable CSRs control whether less-privileged software may access
+     * selected architectural state and extension-specific CSRs.
+     *
+     * In Bao, this is used to define which optional privileged features are
+     * visible to VS-mode guests, while keeping the default policy restrictive.
+     *
+     * Execution reaches this block only when the Ssstateen extension is
+     * implemented by the platform.
+     */
+#if CPU_HAS_EXTENSION(CPU_EXT_SSSTATEEN)
+    /**
+     * Enable and sanity check the custom-state hstateen bit if the platform
+     * implements the compressed extension. Otherwise, keep the bit cleared.
+     *
+     * The write is verified through readback because hstateen fields are
+     * WARL: unsupported bits may read back as zero.
+     */
+    if (CPU_HAS_EXTENSION(CPU_EXT_C)) {
+        csrs_hstateen0_set(HSTATEEN_C);
+        bool custom_state_present = (csrs_hstateen0_read() & HSTATEEN_C) != 0;
+        if (cpu_is_master() && !custom_state_present) {
+            ERROR("Platform configured to allow access to custom state, but extension not "
+                  "avaialble.\r\n");
+        }
+    }
+
+    /**
+     * Enable and sanity check the FCSR-related hstateen bit when floating-point
+     * instructions operate on x registers. Otherwise, keep the bit cleared.
+     */
+    if (!CPU_HAS_EXTENSION(CPU_EXT_F)) {
+        csrs_hstateen0_set(HSTATEEN_FCSR);
+        bool fcsr_not_present = (csrs_hstateen0_read() & HSTATEEN_FCSR) != 0;
+        if (cpu_is_master() && !fcsr_not_present) {
+            ERROR("Platform configured so that floating-point instructions operate on integer "
+                  "registers, but floating-point unit is implemented.\r\n");
+        }
+    }
+
+    /**
+     * Enable and sanity check the context-state hstateen bit when Sdtrig is
+     * implemented. Otherwise, keep the bit cleared.
+     *
+     * This allows guests to access the scontext CSR if the
+     * platform supports it.
+     */
+    if (CPU_HAS_EXTENSION(CPU_EXT_SDTRIG)) {
+        csrs_hstateen0_set(HSTATEEN_CTX);
+        bool sdtrig_state_enabled = (csrs_hstateen0_read() & HSTATEEN_CTX) != 0;
+        if (cpu_is_master() && !sdtrig_state_enabled) {
+            ERROR("Platform configured to use Sdtrig extension, but extension not available.\r\n");
+        }
+    }
+
+    /**
+     * Enable and sanity check the indirect-CSR hstateen bit when Sscsrind is
+     * present. Otherwise, keep the bit cleared.
+     *
+     * Indirect CSR access is required by some optional privileged features,
+     * so it is enabled independently and verified with a WARL readback.
+     */
+    if (CPU_HAS_EXTENSION(CPU_EXT_SSCSRIND)) {
+        csrs_hstateen0_set(HSTATEEN_CSRIND);
+        bool sscrind_ctxt_en = (csrs_hstateen0_read() & HSTATEEN_CSRIND) != 0;
+        if (cpu_is_master() && !sscrind_ctxt_en) {
+            ERROR("Platform configured to use Sscsrind extension, but extension not "
+                  "available.\r\n");
+        }
+    }
+
+    /**
+     * Enable and sanity check the AIA and IMSIC hstateen bits when Bao is
+     * built to use AIA. Otherwise, keep those bits cleared.
+     *
+     * AIA guest support depends on the relevant AIA state being exposed
+     * through hstateen. Sscsrind is checked first because some IMSIC-related
+     * state is accessed through the indirect CSR mechanism.
+     */
+    if (IRQC == AIA) {
+        if (!CPU_HAS_EXTENSION(CPU_EXT_SSCSRIND)) {
+            ERROR("AIA requires Sscsrind extension to be present.");
+        }
+        csrs_hstateen0_set(HSTATEEN_IMSIC | HSTATEEN_AIA);
+        bool aia_ctxt_en =
+            ((csrs_hstateen0_read() & (HSTATEEN_IMSIC | HSTATEEN_AIA | HSTATEEN_CSRIND)) ==
+                (HSTATEEN_IMSIC | HSTATEEN_AIA | HSTATEEN_CSRIND));
+        if (cpu_is_master() && (!aia_ctxt_en)) {
+            ERROR("Platform configured to use AIA and IMSIC extensions, but extensions not "
+                  "available.\r\n");
+        }
+    }
+
+    /**
+     * Enable and sanity check the senvcfg hstateen bit so VS-mode can manage
+     * delegated environment configuration state.
+     */
+    csrs_hstateen0_set(HSTATEEN_ENVCFG);
+    bool senvcfg_ctxt_en = (csrs_hstateen0_read() & HSTATEEN_ENVCFG) != 0;
+    if (cpu_is_master() && (!senvcfg_ctxt_en)) {
+        ERROR("Platform configured to enable senvcfg access to VS-mode but this feature is not "
+              "available.\r\n");
+    }
+
+    /**
+     * Enable the SEO bits in hstateen0 so VS-mode can access the sstateen0
+     * CSR.
+     *
+     */
+    csrs_hstateen0_set(HSTATEEN_SEO);
+#endif
     /**
      * TODO: consider delegating other exceptions e.g. breakpoint or ins misaligned
      */

--- a/src/platform/qemu-riscv64-virt/inc/plat/platform.h
+++ b/src/platform/qemu-riscv64-virt/inc/plat/platform.h
@@ -8,12 +8,16 @@
 
 #include <drivers/sbi_uart.h>
 
-#define CPU_EXT_SSTC   1
-#define CPU_EXT_V      0
-#define CPU_EXT_ZICBOM 1
-#define CPU_EXT_ZICBOZ 1
+#define CPU_EXT_SSTC      1
+#define CPU_EXT_V         0
+#define CPU_EXT_ZICBOM    1
+#define CPU_EXT_ZICBOZ    1
+#define CPU_EXT_F         1
+#define CPU_EXT_C         0
+#define CPU_EXT_SSSTATEEN 0
+#define CPU_EXT_SSCSRIND  0
 
-#define IPIC_SBI       (1)
-#define IPIC_ACLINT    (2)
+#define IPIC_SBI          (1)
+#define IPIC_ACLINT       (2)
 
 #endif


### PR DESCRIPTION
## Summary

Add initial RISC-V `Ssstateen` support for guests.

This change:
- adds CSR definitions and accessors for `sstateen[0..3]` and `hstateen[0..3]`
- adds `hstateen` bit definitions used to control guest-visible optional state
- initializes guest `sstateen[0..3]` to zero during vCPU reset
- configures `hstateen` during hypervisor initialization to selectively expose
  optional state to VS-mode guests
- enables guest access to `senvcfg` through `hstateen`
- adds platform configuration macros for `CPU_EXT_SSSTATEEN`, `CPU_EXT_F`, `CPU_EXT_C`  and
  `CPU_EXT_SSCSRIND`

## Implementation

### CSR support

The patch adds:
- `CSR_SSTATEEN0` to `CSR_SSTATEEN3`
- `CSR_HSTATEEN0` to `CSR_HSTATEEN3`
- RV32 split definitions for `hstateen0h` to `hstateen3h`
- accessor helpers for both supervisor and hypervisor state-enable CSRs

It also introduces the `HSTATEEN_*` and `SSTATEEN_*` bit definitions used by
the initialization code.

### Guest reset state

During `vcpu_arch_reset()`:
- `sstateen[0..3]` are initialized to zero when `CPU_EXT_SSSTATEEN` is enabled
- guest `sstatus`/`vsstatus` floating-point state is only marked dirty when
  the platform advertises `CPU_EXT_F`

This keeps guest-visible optional state disabled by default.

### Hypervisor configuration

During `vmm_arch_init()`, when `CPU_EXT_SSSTATEEN` is enabled, Bao configures
`hstateen` to expose only the intended guest-visible state.

The patch:
- enables `HSTATEEN_C` when custom state is supported
- enables `HSTATEEN_FCSR` when floating-point instructions operate on integer
  registers
- enables `HSTATEEN_CTX` when `Sdtrig` is available
- enables `HSTATEEN_CSRIND` when `Sscsrind` is available
- enables `HSTATEEN_IMSIC` and `HSTATEEN_AIA` when Bao is built with AIA
- enables `HSTATEEN_ENVCFG` so VS-mode can access delegated environment
  configuration state
- enables the SEO bits in `hstateen0-3` so guests may access the
  `sstateen` CSRs themselves

Unsupported WARL bits are verified through readback and reported early.

## Guest-visible behavior

Guests can probe and access the `sstateen` CSRs without implicitly gaining
access to additional privileged state, because the guest `sstateen[0..3]`
registers are initialized to zero.

This improves compatibility with software that checks for the presence of
state-enable CSRs while keeping the default access policy deny-by-default.

## Requirements to run

Running this support requires coordinated changes across Bao, the guest DT, and
QEMU.

### Bao configuration

Enable `Ssstateen` support in the Bao platform configuration for:
- `qemu-riscv32-virt`
- `qemu-riscv64-virt`

Set:
- `CPU_EXT_SSSTATEEN = 1`

If the platform also supports indirect CSR access, set:
- `CPU_EXT_SSCSRIND = 1`

###  Linux / Device Tree

It must also advertise the extensions in riscv,isa.

For RV32:

    riscv,isa = "rv32imafdch_ssstateen_sscsrind_zicntr_zicsr_zifencei_sstc";

For RV64:

    riscv,isa = "rv64imafdch_ssstateen_sscsrind_zicntr_zicsr_zifencei_sstc";


### QEMU

A QEMU version with support for the `sstateen`/`hstateen` CSRs is required.

- RV32 QEMU:
  - use `https://github.com/ninolomata/qemu-bao/tree/riscv-rv32-henvcfg-stateen-fixes`
- RV64 QEMU:
  - use a QEMU build that includes the same `henvcfg`/state-enable CSR support
