### PR TITLE
fix(gpsr): fix the code to allow other GPSR ids other than 0

### DIFF
--- a/src/arch/tricore/inc/arch/platform.h
+++ b/src/arch/tricore/inc/arch/platform.h
@@ -14,7 +14,7 @@
 
 #define IR_MAX_INTERRUPTS (2048U)
 #define HYP_GPSR_GROUP    (0)
-#define IPI_CPU_MSG       (GPSR_SRC_BASE)
+#define IPI_CPU_MSG       (GPSR_SRC_BASE + (HYP_GPSR_GROUP * 8))
 
 // Arch-specific platform data
 struct plat_device {

--- a/src/arch/tricore/vm.c
+++ b/src/arch/tricore/vm.c
@@ -28,8 +28,8 @@ static void vm_ipi_init(struct vm* vm, const struct vm_config* vm_config)
 
     for (unsigned long int i = 0; i < vm_config->platform.arch.gpsr_num; i++) {
         unsigned long group = (unsigned long)vm_config->platform.arch.gpsr_groups[i];
-        if (group == 0) {
-            ERROR("GPSR group 0 is reserved for Bao internal use.\n");
+        if (group == HYP_GPSR_GROUP) {
+            ERROR("GPSR group %d is reserved for Bao internal use.\n", HYP_GPSR_GROUP);
         }
         // We need to clear the group 1st because it allows access to everyone by default
         ir_clear_gpsr_group(group);


### PR DESCRIPTION
This PR fixes some problems where bao was expected to use only the GPSR 0.
The IPI_CPU_MSG was based on bao having always the GPSR id 0. Also, in the vm_ipi_init, the id 0 was hardcoded instead of using the already existing macro