### PR TITLE
Fix undefined behavior in BIT_MASK() for LEN == 0

### DIFF
--- a/src/lib/inc/bit.h
+++ b/src/lib/inc/bit.h
@@ -16,7 +16,8 @@
  */
 #define BIT32_MASK(OFF, LEN) ((((UINT32_C(1) << ((LEN) - 1)) << 1) - 1) << (OFF))
 #define BIT64_MASK(OFF, LEN) ((((UINT64_C(1) << ((LEN) - 1)) << 1) - 1) << (OFF))
-#define BIT_MASK(OFF, LEN)   (((((1UL) << ((LEN) - 1)) << 1) - 1) << (OFF))
+#define BIT_MASK(OFF, LEN) \
+    ((LEN) == 0 ? 0UL : ((((1UL << ((LEN) - 1)) << 1) - 1) << (OFF)))
 
 #ifndef __ASSEMBLER__
 


### PR DESCRIPTION
This PR fixes undefined behavior in `BIT_MASK(OFF, LEN)` when `LEN = 0`.

Previous implementation could evaluate `1UL << -1` resulting in an invalid negative shift and undefined behavior.

The fix:

- Safely handles LEN == 0
- Removes undefined behavior
- Preserves existing behavior for valid non-zero lengths