### PR TITLE
fix(core): pCPU ID to vCPU ID translation

### DIFF
--- a/src/core/inc/vm.h
+++ b/src/core/inc/vm.h
@@ -150,7 +150,7 @@ static inline cpuid_t vm_translate_to_pcpuid(struct vm* vm, vcpuid_t vcpuid)
 static inline vcpuid_t vm_translate_to_vcpuid(struct vm* vm, cpuid_t pcpuid)
 {
     if (vm->cpus & (1UL << pcpuid)) {
-        return (cpuid_t)bit_count(vm->cpus & BIT_MASK(0, pcpuid));
+        return (cpuid_t)bit_count(vm->cpus & ((1UL << pcpuid) - 1UL));
     } else {
         return INVALID_CPUID;
     }

--- a/src/lib/inc/bit.h
+++ b/src/lib/inc/bit.h
@@ -9,8 +9,9 @@
 #include <bao.h>
 
 /**
+ * The bit mask macros support LEN within [1, BITS_PER_LONG]. LEN == 0 is not supported.
  * The extra shift is because both arm and riscv logical shift instructions support a maximum of
- * machine word length minus one bit shits. This covers the corner case of runtime full machine
+ * machine word length minus one bit shifts. This covers the corner case of runtime full machine
  * word length masks with the cost of an extra shift instruction. For static masks, there should be
  * no extra costs.
  */


### PR DESCRIPTION
This PR fixes an invalid `BIT_MASK()` usage in `vm_translate_to_vcpuid()` when `pcpuid == 0`.

`BIT_MASK()` expects LEN values within `[1, BITS_PER_LONG]`, making `LEN=0` unsupported by design. The previous implementation could invoke the macro with `LEN=0`, leading to undefined behavior.

The logic has been updated to avoid the unsupported case while preserving the original behavior and keeping the existing `BIT_MASK()` implementation unchanged.

Additionally, a note has been added to the `BIT_MASK()` declaration documenting the supported `LEN` range and explicitly stating that `LEN=0` is not supported.