### PR TITLE
Fix RH850 vIPIR emulation

### DIFF
--- a/src/arch/rh850/inc/arch/emul.h
+++ b/src/arch/rh850/inc/arch/emul.h
@@ -33,7 +33,8 @@ static inline bool emul_arch_is_bwop(struct emul_access_arch* acc)
 static inline uint8_t emul_arch_bwop_emul_acc(struct emul_access_arch* acc, uint8_t cur_val)
 {
     unsigned long psw = srs_gmpsw_read();
-    if (cur_val & acc->bit) {
+    uint8_t bitmask = (uint8_t)(1UL << acc->bit);
+    if (cur_val & bitmask) {
         srs_gmpsw_write(psw & ~PSW_Z);
     } else {
         srs_gmpsw_write(psw | PSW_Z);
@@ -41,15 +42,15 @@ static inline uint8_t emul_arch_bwop_emul_acc(struct emul_access_arch* acc, uint
     uint8_t val = 0;
     switch (acc->bwop) {
         case EMUL_ARCH_BWOP_SET1:
-            val = (uint8_t)(cur_val | acc->bit);
+            val = (uint8_t)(cur_val | bitmask);
             ;
             break;
         case EMUL_ARCH_BWOP_NOT1:
-            val = (uint8_t)(cur_val ^ acc->bit);
+            val = (uint8_t)(cur_val ^ bitmask);
             ;
             break;
         case EMUL_ARCH_BWOP_CLR1:
-            val = (uint8_t)(cur_val & (uint8_t)~acc->bit);
+            val = (uint8_t)(cur_val & (uint8_t)~bitmask);
             ;
             break;
             /* TST1 only modifies the PSW.Z flag */

--- a/src/arch/rh850/vipir.c
+++ b/src/arch/rh850/vipir.c
@@ -70,27 +70,17 @@ static bool vipir_emul_handler(struct emul_access* acc)
     }
 
     if ((chan_idx != IPI_HYP_IRQ_ID) && (tgt_reg != NULL)) {
-        if (acc->write) {
-            unsigned long val;
-            if (emul_arch_is_bwop(&acc->arch)) {
-                val = (uint8_t)emul_arch_bwop_emul_acc(&acc->arch, *tgt_reg);
-            } else {
-                val = (uint8_t)vcpu_readreg(vcpu, acc->reg);
-            }
-            val = (uint8_t)vm_translate_to_pcpu_mask(vm, val, vm->cpu_num);
+        if (emul_arch_is_bwop(&acc->arch)) {
+            acc->arch.bit = (uint8_t)vm_translate_to_pcpuid(vm, acc->arch.bit);
+            *tgt_reg = emul_arch_bwop_emul_acc(&acc->arch, *tgt_reg);
+        } else if (acc->write) {
+            unsigned long val = (uint8_t)vcpu_readreg(vcpu, acc->reg);
+            val = (uint8_t)vm_translate_to_pcpu_mask(vm, val, PLAT_CPU_NUM);
             *tgt_reg = (uint8_t)((*tgt_reg & ~vm->cpus) | (val & vm->cpus));
         } else {
             uint8_t val = *tgt_reg;
-            if (emul_arch_is_bwop(&acc->arch)) {
-                /* translate vcpu_id bit to pcpu_id bit */
-                acc->arch.bit =
-                    (uint8_t)vm_translate_to_pcpu_mask(vm, val & acc->arch.bit, vm->cpu_num);
-                /* invoke emul to update gmpsw.z */
-                (void)emul_arch_bwop_emul_acc(&acc->arch, val);
-            } else {
-                val = (uint8_t)vm_translate_to_pcpu_mask(vm, val, vm->cpu_num);
-                vcpu_writereg(vcpu, acc->reg, val);
-            }
+            val = (uint8_t)vm_translate_to_vcpu_mask(vm, val, PLAT_CPU_NUM);
+            vcpu_writereg(vcpu, acc->reg, val);
         }
     }
 


### PR DESCRIPTION
The previous vIPIR emulation handler had a few issues:

- Bitwise instructions were incorrectly treated as a subset of read/write instructions.
- pCPU↔vCPU mask translation was using the number of CPUs in the current VM instead of the number of CPUs in the platform.
- Read operations were incorrectly translating masks back to pCPU masks instead of returning vCPU masks.

This PR fixes these issues and updates acc->arch.bit to store the actual bit mask associated with the bitwise instruction, rather than the bit index.

:warning: Depends on #361 