### PR TITLE
fix(riscv): use ~0ULL when programming stimecmp to "infinity"

### DIFF
--- a/src/arch/riscv/vmm.c
+++ b/src/arch/riscv/vmm.c
@@ -34,7 +34,7 @@ void vmm_arch_init()
         }
         // Set stimecmp to infinity in case we enable the stimer interrupt somewhere else
         // and fail to set the timer to a point in the future.
-        csrs_stimecmp_write(~0U);
+        csrs_stimecmp_write(~0ULL);
     } else {
         csrs_henvcfg_clear(HENVCFG_STCE);
     }


### PR DESCRIPTION
~0U is a 32-bit unsigned literal; when widened to the 64-bit parameter of csrs_stimecmp_write() it is zero-extended, leaving stimecmp with the upper half cleared instead of all ones. Affects both RV32 and RV64.