### PR TITLE
feat(pmbt): add pmbt extension support

### DIFF
--- a/src/arch/riscv/inc/arch/page_table.h
+++ b/src/arch/riscv/inc/arch/page_table.h
@@ -8,6 +8,7 @@
 
 #include <bao.h>
 #include <bit.h>
+#include <plat/cpu_ext.h>
 
 #define HYP_ROOT_PT_SIZE (PAGE_SIZE)
 #define PAGE_SHIFT       (12)
@@ -23,7 +24,24 @@
 #define PTE_ADDR_MSK PTE_MASK(12, 44)
 #endif
 
-#define PTE_FLAGS_MSK             PTE_MASK(0, 8)
+#define PTE_PBMT_OFF 61
+#define PTE_PBMT_PMA (0ULL << PTE_PBMT_OFF)
+#define PTE_PBMT_NC  (1ULL << PTE_PBMT_OFF)
+#define PTE_PBMT_IO  (2ULL << PTE_PBMT_OFF)
+
+#if defined(RV64) && defined(CPU_EXT_SVPBMT) && (CPU_EXT_SVPBMT == 1)
+#define PTE_PBMT_FLAGS_MSK PTE_MASK(PTE_PBMT_OFF, 2)
+#define PTE_PBMT_DEV_FLAGS PTE_PBMT_IO
+#else
+#define PTE_PBMT_FLAGS_MSK 0ULL
+#define PTE_PBMT_DEV_FLAGS 0ULL
+#endif
+
+#define PTE_FLAGS_BASE_MSK        PTE_MASK(0, 8)
+#define PTE_FLAGS_EXT_MSK         PTE_PBMT_FLAGS_MSK
+#define PTE_FLAGS_MSK             (PTE_FLAGS_BASE_MSK | PTE_FLAGS_EXT_MSK)
+
+#define PTE_DEV_FLAGS             PTE_PBMT_DEV_FLAGS
 
 #define PTE_VALID                 (1ULL << 0)
 #define PTE_READ                  (1ULL << 1)
@@ -64,10 +82,10 @@
 
 #define PTE_INVALID               (0)
 #define PTE_HYP_FLAGS             (PTE_GLOBAL | PTE_ACCESS | PTE_DIRTY)
-#define PTE_HYP_DEV_FLAGS         PTE_HYP_FLAGS
+#define PTE_HYP_DEV_FLAGS         (PTE_HYP_FLAGS | PTE_DEV_FLAGS)
 
 #define PTE_VM_FLAGS              (PTE_ACCESS | PTE_DIRTY | PTE_USER)
-#define PTE_VM_DEV_FLAGS          PTE_VM_FLAGS
+#define PTE_VM_DEV_FLAGS          (PTE_VM_FLAGS | PTE_DEV_FLAGS)
 
 #ifndef __ASSEMBLER__
 

--- a/src/arch/riscv/vmm.c
+++ b/src/arch/riscv/vmm.c
@@ -5,6 +5,7 @@
 
 #include <vmm.h>
 #include <arch/csrs.h>
+#include <arch/page_table.h>
 
 void vmm_arch_init()
 {
@@ -43,6 +44,14 @@ void vmm_arch_init()
         csrs_stimecmp_write(~0ULL);
     } else {
         csrs_henvcfg_clear(HENVCFG_STCE);
+    }
+
+    if (CPU_HAS_EXTENSION(CPU_EXT_SVPBMT)) {
+        csrs_henvcfg_set(HENVCFG_PBMTE);
+        bool svpbmt_present = (csrs_henvcfg_read() & HENVCFG_PBMTE) != 0;
+        if (cpu_is_master() && !svpbmt_present) {
+            ERROR("Platform configured to use SVPBMT extensions, but extension not present.\r\n");
+        }
     }
 
     /**

--- a/src/platform/qemu-riscv64-virt/inc/plat/cpu_ext.h
+++ b/src/platform/qemu-riscv64-virt/inc/plat/cpu_ext.h
@@ -1,0 +1,12 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved
+ */
+
+#ifndef __PLAT_CPU_EXT_H__
+#define __PLAT_CPU_EXT_H__
+
+#define CPU_EXT_SSTC   1
+#define CPU_EXT_SVPBMT 1
+
+#endif

--- a/src/platform/qemu-riscv64-virt/inc/plat/platform.h
+++ b/src/platform/qemu-riscv64-virt/inc/plat/platform.h
@@ -6,6 +6,8 @@
 #ifndef __PLAT_PLATFORM_H__
 #define __PLAT_PLATFORM_H__
 
+#include <plat/cpu_ext.h>
+
 #include <drivers/sbi_uart.h>
 
 #define CPU_EXT_SSTC      1


### PR DESCRIPTION
## Summary

Add initial RISC-V Svpbmt support for selecting page-based memory types in Bao page-table entries.

This change:

- adds PBMT PTE field definitions
- allows PBMT bits in RISC-V PTE flags when `CPU_EXT_SVPBMT` is enabled
- marks device mappings as PBMT I/O mappings
- enables `henvcfg.PBMTE` during hypervisor init when Svpbmt is configured
- adds platform configuration plumbing for `CPU_EXT_SVPBMT`

## Implementation

The patch:

- adds PBMT encodings for:
  - `PTE_PBMT_PMA`
  - `PTE_PBMT_NC`
  - `PTE_PBMT_IO`
- extends the RISC-V PTE flag mask to include PBMT bits only when Svpbmt is enabled
- adds extension-specific PTE flag plumbing so future PTE extensions can contribute their own masks/flags
- updates device mapping flags to use `PTE_PBMT_IO` when Svpbmt is enabled
- checks Svpbmt availability by setting and reading back `henvcfg.PBMTE`
- moves platform CPU extension macros into an assembler-safe `plat/cpu_ext.h` header so page-table code can use them without pulling C-only platform declarations into assembly

## Requirements to run

Running this support requires coordinated support from Bao and QEMU.

## Bao configuration

Enable Svpbmt in the platform CPU extension configuration:

```c
#define CPU_EXT_SVPBMT 1
```
When enabled, Bao will:

set henvcfg.PBMTE
allow PBMT bits in PTEs
use PBMT I/O attributes for device mappings

# QEMU
A QEMU version with Svpbmt support is required.

For QEMU virt platforms, make sure the selected CPU exposes Svpbmt, for example with an appropriate CPU option such as:
```c
svpbmt=true
```