### PR TITLE
fix(riscv/sbi): do not truncate the HSM hart_start opaque (priv)

### DIFF
--- a/src/arch/riscv/inc/arch/sbi.h
+++ b/src/arch/riscv/inc/arch/sbi.h
@@ -33,7 +33,10 @@ struct sbi_hsm {
     spinlock_t lock;
     enum { STARTED, STOPPED, START_PENDING, STOP_PENDING } state;
     vaddr_t start_addr;
-    unsigned priv;
+    /* SBI HSM hart_start 'opaque' arg, handed to the started hart in a1. It is a
+     * full xlen value (Linux passes a 64-bit guest-physical pointer here), so it
+     * must not be truncated. */
+    unsigned long priv;
 };
 
 void sbi_init(void);

--- a/src/arch/riscv/sbi.c
+++ b/src/arch/riscv/sbi.c
@@ -351,7 +351,7 @@ static struct sbiret sbi_hsm_start_handler(void)
                 ret.error = SBI_ERR_FAILURE;
             } else {
                 vaddr_t start_addr = vcpu_readreg(cpu()->vcpu, REG_A1);
-                unsigned priv = (unsigned)vcpu_readreg(cpu()->vcpu, REG_A2);
+                unsigned long priv = vcpu_readreg(cpu()->vcpu, REG_A2);
                 vcpu->arch.sbi_ctx.state = START_PENDING;
                 vcpu->arch.sbi_ctx.start_addr = start_addr;
                 vcpu->arch.sbi_ctx.priv = priv;


### PR DESCRIPTION
Fix truncation of the opaque (priv) argument passed to the vcpu on SBI HSM hart_start.