### PR TITLE
feat(plat): add SpacemiT K3 CoM260 support

### DIFF
--- a/src/platform/drivers/8250_uart/8250_uart.c
+++ b/src/platform/drivers/8250_uart/8250_uart.c
@@ -32,6 +32,13 @@ void uart_init(volatile struct uart8250_hw* uart)
 
 void uart_enable(volatile struct uart8250_hw* uart)
 {
+#ifdef UART8250_XSCALE
+    /**
+     * XScale/PXA-style ports gate the whole UART on the IER Unit Enable (UUE) bit, so it must be
+     * set for the unit to operate.
+     */
+    uart->ier |= UART8250_IER_UUE;
+#endif
     uart->fcr = UART8250_FCR_EN;
 }
 

--- a/src/platform/drivers/8250_uart/inc/drivers/8250_uart.h
+++ b/src/platform/drivers/8250_uart/inc/drivers/8250_uart.h
@@ -58,6 +58,8 @@ struct uart8250_hw {
 #define UART8250_LCR_DLAB   (0x1 << 7)
 #define UART8250_LCR_8BIT   (0x3 << 0)
 
+#define UART8250_IER_UUE    (0x1 << 6)
+
 #define UART8250_FCR_TX_CLR (0x1 << 2)
 #define UART8250_FCR_RX_CLR (0x1 << 1)
 #define UART8250_FCR_EN     (0x1 << 0)

--- a/src/platform/k3-com260/inc/plat/cpu_ext.h
+++ b/src/platform/k3-com260/inc/plat/cpu_ext.h
@@ -1,0 +1,27 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved
+ */
+
+#ifndef __PLAT_CPU_EXT_H__
+#define __PLAT_CPU_EXT_H__
+
+/*
+ * CPU extensions the X100 (cpu@0-7) harts implement, from the vendor DT
+ * riscv,isa = "rv64imafdcvh" + isa-extensions (smaia, ssaia, smstateen, sstc,
+ * sdtrig, ...). Bao only acts on the ones it tracks; defining them makes the
+ * hypervisor handle guest state correctly. CRITICAL: the whole hstateen
+ * state-enable block in vmm.c (which grants VS-mode guests access to the
+ * AIA/IMSIC indirect CSRs they need) is gated on CPU_EXT_SSSTATEEN, and its AIA
+ * path requires CPU_EXT_SSCSRIND.
+ */
+#define CPU_EXT_F         1 /* f + d: guest uses the FPU (sstatus.FS), so Bao must ctx-switch it */
+#define CPU_EXT_V         1 /* v: vector unit (sstatus.VS), so Bao must ctx-switch it */
+#define CPU_EXT_ZICBOM    1 /* cbo.clean/flush/inval - Linux uses these for DMA cache mgmt */
+#define CPU_EXT_ZICBOZ    1 /* cbo.zero */
+#define CPU_EXT_SVPBMT    1 /* page-based memory types - Linux uses PBMT (NC) for device ioremap */
+#define CPU_EXT_SSTC      1 /* per-hart supervisor timer (sstc) */
+#define CPU_EXT_SSSTATEEN 1 /* smstateen + H => hstateen CSRs (enables the vmm.c block) */
+#define CPU_EXT_SSCSRIND  1 /* indirect CSRs (siselect/sireg) - required by Ssaia/AIA */
+
+#endif

--- a/src/platform/k3-com260/inc/plat/platform.h
+++ b/src/platform/k3-com260/inc/plat/platform.h
@@ -1,0 +1,20 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved
+ */
+
+#ifndef __PLAT_PLATFORM_H__
+#define __PLAT_PLATFORM_H__
+
+/* K3 UART0: XScale/PXA-style 16550, 32-bit registers (reg-shift=2, reg-io-width=4),
+ * registers start at the page base (no page offset). */
+#define UART8250_REG_WIDTH (4)
+#define UART8250_XSCALE    (1)
+
+#include <drivers/8250_uart.h>
+#include <plat/cpu_ext.h>
+
+#define IPIC_SBI    (1)
+#define IPIC_ACLINT (2)
+
+#endif

--- a/src/platform/k3-com260/k3_com260_desc.c
+++ b/src/platform/k3-com260/k3_com260_desc.c
@@ -1,0 +1,32 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <platform.h>
+
+struct platform platform = {
+
+    .cpu_num = 8,
+
+    .region_num = 1,
+    .regions = (struct mem_region[]) {
+        {
+            .base = 0x102000000,
+            .size = 0x1fe000000,
+        },
+    },
+
+    /* K3 UART0: the hypervisor's own console (page-aligned base). */
+    .console = {
+        .base = 0xd4017000,
+    },
+
+    .arch = {
+        .irqc.aia.aplic.base = 0xe0804000,
+        .irqc.aia.imsic.base = 0xe0400000,
+        .irqc.aia.imsic.num_msis = 511,
+        .irqc.aia.imsic.num_guest_files = 63,
+    },
+
+};

--- a/src/platform/k3-com260/objects.mk
+++ b/src/platform/k3-com260/objects.mk
@@ -1,0 +1,4 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+boards-objs-y+=k3_com260_desc.o

--- a/src/platform/k3-com260/platform.mk
+++ b/src/platform/k3-com260/platform.mk
@@ -1,0 +1,33 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+# SpacemiT K3 (X100 cluster) - e.g. CoM260 Kit
+#
+# Only the 8 X100 application harts (cpu@0-7) implement the RISC-V hypervisor
+# (H) extension, so Bao runs on those. The A100 harts (cpu@8-15) lack H and are
+# intentionally left out of the platform description.
+
+# Architecture definition
+ARCH:=riscv
+# CPU definition
+CPU:=
+# Interrupt controller definition (Advanced Interrupt Architecture: APLIC + IMSIC)
+IRQC:=AIA
+# Core IPIs controller (SBI IPI, provided by the resident M-mode OpenSBI)
+IPIC:=IPIC_SBI
+
+# The hypervisor drives the K3 UART0 directly for its own debug output. The K3
+# UART (spacemit,k1-uart / intel,xscale-uart) is a 16550/8250-compatible block
+# with 32-bit registers spaced 4 bytes apart (reg-shift=2, reg-io-width=4) - the
+# same UART OpenSBI drives with its generic 8250 driver - so Bao's stock
+# 8250_uart driver covers it directly (see UART8250_REG_WIDTH in platform.h).
+# The same UART0 is also passed through to the guest (see configs/k3-com260),
+# so during early boot the two briefly share the line, which is fine for bring-up.
+drivers := 8250_uart
+
+platform_description:=k3_com260_desc.c
+
+platform-cppflags =-DIPIC=$(IPIC)
+platform-cflags =
+platform-asflags =
+platform-ldflags =


### PR DESCRIPTION
Add support for the SpacemiT K3 CoM260 platform, along with XScale/PXA-style 8250 UART support (IER UUE bit).

For correct execution this PR depends on #367 and #368 