### PR TITLE
misc rh850 fixes

### DIFF
--- a/src/arch/rh850/aborts.c
+++ b/src/arch/rh850/aborts.c
@@ -126,18 +126,6 @@ static void decode_access(struct emul_access* acc, unsigned long addr)
     if (opcode == F8_OPCODE) {
         bit = (inst & BITIDX_MASK) >> BITIDX_SHIFT;
         bwop = ((inst & SUB8_MASK) >> SUB8_SHIFT) + 1;
-        int16_t imm = (int16_t)(inst >> 16);
-        if (imm < 0) {
-            if ((unsigned long)(-imm) > addr) {
-                ERROR("bitwise addr underflow\n")
-            }
-        } else {
-            if (addr > UINT32_MAX - (unsigned long)imm) {
-                ERROR("bitwise addr overflow\n")
-            }
-        }
-
-        addr = (unsigned long)((signed long)addr + imm);
     } else if (opcode == F9_OPCODE && subopcode == F9_SUBOPCODE) {
         unsigned long reg_idx = (inst & REGIDX_MASK) >> REGIDX_SHIFT;
         /* only the three LSB of register val are used as bit index */

--- a/src/arch/rh850/vintc.c
+++ b/src/arch/rh850/vintc.c
@@ -48,7 +48,7 @@ static void emulate_intc_eic_access(struct emul_access* acc)
 
     size_t acc_intc2_offset = acc->addr - (unsigned long)intc2_hw;
     unsigned long bot = offsetof(struct intc2, EIC);
-    size_t reg_idx = (ALIGN(acc_intc2_offset - bot, 2)) / 2;
+    size_t reg_idx = (acc_intc2_offset - bot) / 2;
 
     unsigned long mask = BIT_MASK(0, acc->width * 8);
     size_t addr_off = acc->addr & 0x1UL;
@@ -85,7 +85,7 @@ static void emulate_intc_imr_access(struct emul_access* acc)
 
     size_t acc_intc2_offset = acc->addr - (unsigned long)intc2_hw;
     unsigned long bot = offsetof(struct intc2, IMR);
-    size_t reg_idx = (ALIGN(acc_intc2_offset - bot, 4)) / 4;
+    size_t reg_idx = (acc_intc2_offset - bot) / 4;
 
     unsigned long mask = BIT_MASK(0, acc->width * 8);
     size_t addr_off = acc->addr & 0x3UL;
@@ -141,7 +141,7 @@ static void emulate_intc_eibd_access(struct emul_access* acc)
 
     size_t acc_intc2_offset = acc->addr - (unsigned long)intc2_hw;
     unsigned long bot = offsetof(struct intc2, EIBD);
-    size_t reg_idx = (ALIGN(acc_intc2_offset - bot, 4)) / 4;
+    size_t reg_idx = (acc_intc2_offset - bot) / 4;
 
     unsigned long mask = BIT_MASK(0, acc->width * 8);
     size_t addr_off = acc->addr & 0x3UL;
@@ -192,7 +192,7 @@ static void emulate_intc_eeic_access(struct emul_access* acc)
 
     size_t acc_intc2_offset = acc->addr - (unsigned long)intc2_hw;
     unsigned long bot = offsetof(struct intc2, EEIC);
-    size_t reg_idx = (ALIGN(acc_intc2_offset - bot, 4)) / 4;
+    size_t reg_idx = (acc_intc2_offset - bot) / 4;
 
     unsigned long mask = BIT_MASK(0, acc->width * 8);
     size_t addr_off = acc->addr & 0x3UL;


### PR DESCRIPTION
ALIGN rounds the memory address up causing the emulation handler to try to configure the wrong interrupt.

The fault address of a bitwise operation is the final address, already reflecting base + imm from the instruction opcode.
