### PR TITLE
fix(e3650): change generic timer freq

### DIFF
--- a/src/platform/e3650/e3650_desc.c
+++ b/src/platform/e3650/e3650_desc.c
@@ -33,7 +33,7 @@ struct platform platform = {
         },
 
         .generic_timer = {
-            .fixed_freq = 600000000,
+            .fixed_freq = 6000000,
         },
 
         .clusters = {


### PR DESCRIPTION
This pull request makes a small change to the `src/platform/e3650/e3650_desc.c` file, specifically updating the `fixed_freq` value for the `generic_timer` configuration. 