### PR TITLE
fix(armv8/vgicv3): fix GICR ISACTIVER and ICACTIVER handler mappings

### DIFF
--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -789,7 +789,7 @@ struct vgic_reg_handler_info icpendr_info = {
     vgic_int_state_hw,
 };
 
-struct vgic_reg_handler_info iactiver_info = {
+struct vgic_reg_handler_info icactiver_info = {
     vgic_emul_generic_access,
     0x4,
     VGIC_ICACTIVER_ID,
@@ -894,7 +894,7 @@ struct vgic_reg_handler_info* reg_handler_info_table[VGIC_REG_HANDLER_ID_NUM] = 
     [VGIC_ISACTIVER_ID] = &isactiver_info,
     [VGIC_ICENABLER_ID] = &icenabler_info,
     [VGIC_ICPENDR_ID] = &icpendr_info,
-    [VGIC_ICACTIVER_ID] = &iactiver_info,
+    [VGIC_ICACTIVER_ID] = &icactiver_info,
     [VGIC_ICFGR_ID] = &icfgr_info,
     [VGIC_IROUTER_ID] = &irouter_info,
     [VGIC_IPRIORITYR_ID] = &ipriorityr_info,
@@ -942,7 +942,7 @@ bool vgicd_emul_handler(struct emul_access* acc)
             handler_info = &icpendr_info;
             break;
         case GICD_REG_GROUP(ICACTIVER):
-            handler_info = &iactiver_info;
+            handler_info = &icactiver_info;
             break;
         case GICD_REG_GROUP(ICFGR):
             handler_info = &icfgr_info;

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -175,7 +175,7 @@ extern struct vgic_reg_handler_info ispendr_info;
 extern struct vgic_reg_handler_info isactiver_info;
 extern struct vgic_reg_handler_info icenabler_info;
 extern struct vgic_reg_handler_info icpendr_info;
-extern struct vgic_reg_handler_info iactiver_info;
+extern struct vgic_reg_handler_info icactiver_info;
 extern struct vgic_reg_handler_info icfgr_info;
 extern struct vgic_reg_handler_info ipriorityr_info;
 extern struct vgic_reg_handler_info razwi_info;
@@ -241,7 +241,7 @@ static bool vgicr_emul_handler(struct emul_access* acc)
             handler_info = &ispendr_info;
             break;
         case GICR_REG_OFF(ISACTIVER0):
-            handler_info = &iactiver_info;
+            handler_info = &isactiver_info;
             break;
         case GICR_REG_OFF(ICENABLER0):
             handler_info = &icenabler_info;
@@ -250,7 +250,7 @@ static bool vgicr_emul_handler(struct emul_access* acc)
             handler_info = &icpendr_info;
             break;
         case GICR_REG_OFF(ICACTIVER0):
-            handler_info = &icfgr_info;
+            handler_info = &icactiver_info;
             break;
         case GICR_REG_OFF(ICFGR0):
         case GICR_REG_OFF(ICFGR1):


### PR DESCRIPTION
This PR fixes the vGICR register emulation where ISACTIVER0 was incorrectly routed to the ICACTIVER handler and ICACTIVER0 was incorrectly routed to the ICFGR handler. Also fix the typo in the variable name iactiver_info -> icactiver_info.

Fixes #374 