### PR TITLE
qemu-riscv: skip SVPBMT for rv32

### DIFF
--- a/src/platform/qemu-riscv64-virt/inc/plat/cpu_ext.h
+++ b/src/platform/qemu-riscv64-virt/inc/plat/cpu_ext.h
@@ -6,7 +6,9 @@
 #ifndef __PLAT_CPU_EXT_H__
 #define __PLAT_CPU_EXT_H__
 
-#define CPU_EXT_SSTC   1
+#define CPU_EXT_SSTC 1
+#if !defined(RV32)
 #define CPU_EXT_SVPBMT 1
+#endif
 
 #endif


### PR DESCRIPTION
This skips defining SVPBMT for RV32 to follow RiscV spec.