### PR TITLE
fix(mem): invalidate TLB after mem_map to make new PTEs visible

### DIFF
--- a/src/arch/riscv/mem.c
+++ b/src/arch/riscv/mem.c
@@ -7,6 +7,7 @@
 
 #include <platform.h>
 #include <cpu.h>
+#include <tlb.h>
 
 static inline void as_map_physical_identity(struct addr_space* as)
 {
@@ -68,4 +69,26 @@ bool mem_translate(struct addr_space* as, vaddr_t va, paddr_t* pa)
     } else {
         return false;
     }
+}
+
+/**
+ * RISC-V permits implementations to cache invalid PTEs unless Svvptc is
+ * implemented (the SiFive P550 does; QEMU does not, which masks the bug), so
+ * after an invalid->valid transition a hart may keep faulting on the new
+ * mapping until the cached negative entry is evicted. Invalidate so the
+ * walker re-reads the new PTEs. tlb_inv_all already scopes the fence to the
+ * address space: hfence.gvma restricted to the VM's VMID for guest address
+ * spaces, sfence.vma for the hypervisor's.
+ *
+ * TODO: for small num_pages a ranged invalidation over [va, va + num_pages)
+ * would preserve the rest of the VMID's cached translations, but ranged
+ * remote fences run as per-page loops in the SBI implementation, so bulk
+ * mappings (VM RAM regions) must keep the full flush; picking the crossover
+ * threshold needs measurement. The va/num_pages parameters exist for this.
+ */
+void mem_arch_map_sync_tlbs(struct addr_space* as, vaddr_t va, size_t num_pages)
+{
+    UNUSED_ARG(va);
+    UNUSED_ARG(num_pages);
+    tlb_inv_all(as);
 }

--- a/src/core/inc/mem.h
+++ b/src/core/inc/mem.h
@@ -71,6 +71,7 @@ vaddr_t mem_alloc_map_dev(struct addr_space* as, as_sec_t section, vaddr_t at, p
 void mem_unmap(struct addr_space* as, vaddr_t at, size_t num_pages, bool free_ppages);
 bool mem_map_reclr(struct addr_space* as, vaddr_t va, struct ppages* ppages, size_t num_pages,
     mem_flags_t flags);
+void mem_arch_map_sync_tlbs(struct addr_space* as, vaddr_t va, size_t num_pages);
 vaddr_t mem_map_cpy(struct addr_space* ass, struct addr_space* asd, as_sec_t asd_section,
     vaddr_t vas, vaddr_t vad, size_t num_pages);
 bool pp_alloc(struct page_pool* pool, size_t num_pages, bool aligned, struct ppages* ppages);

--- a/src/core/mem.c
+++ b/src/core/mem.c
@@ -519,6 +519,21 @@ __attribute__((weak)) bool mem_map_reclr(struct addr_space* as, vaddr_t va, stru
     ERROR("Trying to recolor section but there is no coloring implementation\n");
 }
 
+/**
+ * Called after mem_map installs new (previously invalid) PTEs, before the
+ * address space locks are released. Architectures whose page-table walkers may
+ * cache invalid entries must override this to make the new mappings visible.
+ * The default is a no-op: Armv8, for instance, forbids caching invalid
+ * translations, so an invalid->valid transition needs no TLB maintenance.
+ */
+__attribute__((weak)) void mem_arch_map_sync_tlbs(struct addr_space* as, vaddr_t va,
+    size_t num_pages)
+{
+    UNUSED_ARG(as);
+    UNUSED_ARG(va);
+    UNUSED_ARG(num_pages);
+}
+
 __attribute__((weak)) bool pp_alloc_clr(struct page_pool* pool, size_t num_pages, colormap_t colors,
     struct ppages* ppages)
 {

--- a/src/core/mmu/mem.c
+++ b/src/core/mmu/mem.c
@@ -580,9 +580,10 @@ static bool mem_map(struct addr_space* as, vaddr_t va, struct ppages* ppages, si
 
     fence_sync();
 
+    mem_arch_map_sync_tlbs(as, va & ~((vaddr_t)(PAGE_SIZE - 1)), num_pages);
+
     if (sec->shared) {
         spin_unlock(&sec->lock);
-        // TODO tlb shootdown?
     }
     spin_unlock(&as->lock);
 


### PR DESCRIPTION
The RISC-V privileged spec permits implementations to cache invalid PTEs: making a stored valid PTE visible to the page-table walker then requires an sfence.vma. Only the Svvptc extension waives this — it was ratified precisely to guarantee invalid->valid updates become visible without a fence. mem_map() only issued a data fence (fence_sync()) after writing PTEs, which orders the stores but does not invalidate cached translations; the pre-existing "// TODO tlb shootdown?" comment suggests this was a known gap.

On cores that exercise this permission, the first access through a fresh mapping faults. Observed on the SiFive P550 (ESWIN EIC7700X, Milk-V Megrez): the memset of a just-mapped page table in vm_mem_prot_init() store-page-faults during VM setup, before any guest runs. QEMU/TCG makes PTE stores visible immediately, which is why CI does not reproduce it.

tlb_inv_all(as) is used instead of per-page tlb_inv_va(): mem_map() writes entries at mixed page/superpage granularity, and its common callers map whole VM images and memory regions (thousands of pages), where a single address-space-scoped invalidation is cheaper than one fence per page. mem_map() is not on any hot path.