### PR TITLE
fix(riscv): only access henvcfg/senvcfg when a configured extension n…

### DIFF
--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -33,6 +33,10 @@ endif
 irqc_arch_dir=$(cpu_arch_dir)/irqc/$(IRQC_DIR)
 src_dirs+=$(irqc_arch_dir)
 
+# Privileged architecture version. Bao assumes >= 1.12; pre-1.12 platforms override.
+RISCV_PRIV_VERSION ?= RISCV_PRIV_VERSION_1_12
+arch-cppflags += -DRISCV_PRIV_VERSION=$(RISCV_PRIV_VERSION)
+
 ifeq ($(ARCH_SUB), riscv64)
 arch-cppflags+=-DRV_XLEN=64
 else ifeq ($(ARCH_SUB), riscv32)

--- a/src/arch/riscv/inc/arch/csrs.h
+++ b/src/arch/riscv/inc/arch/csrs.h
@@ -6,6 +6,11 @@
 #ifndef __ARCH_CSR_H__
 #define __ARCH_CSR_H__
 
+/* Privileged-arch version (set per-platform in platform.mk); selects CSR availability. */
+#define RISCV_PRIV_VERSION_1_11 (11)
+#define RISCV_PRIV_VERSION_1_12 (12)
+#define RISCV_PRIV_VERSION_1_13 (13)
+
 #include <bao.h>
 
 #define CSR_SISELECT      0x150

--- a/src/arch/riscv/vm.c
+++ b/src/arch/riscv/vm.c
@@ -62,7 +62,10 @@ void vcpu_arch_reset(struct vcpu* vcpu, vaddr_t entry)
         csrs_sstateen0_write(0);
     }
 
+    /* senvcfg is priv-1.12 like henvcfg (see vmm.c); gate on RISCV_PRIV_VERSION. */
+#if RISCV_PRIV_VERSION >= RISCV_PRIV_VERSION_1_12
     csrs_senvcfg_write(0);
+#endif
     csrs_hcounteren_write(HCOUNTEREN_TM);
     csrs_htimedelta_write(0);
     csrs_vsstatus_write(SSTATUS_SD | SSTATUS_FS_DIRTY | SSTATUS_XS_DIRTY);

--- a/src/arch/riscv/vmm.c
+++ b/src/arch/riscv/vmm.c
@@ -22,11 +22,14 @@ void vmm_arch_init()
     csrs_hideleg_write(HIDELEG_VSSI | HIDELEG_VSTI | HIDELEG_VSEI);
     csrs_hedeleg_write(HEDELEG_BKP | HEDELEG_ECU | HEDELEG_IPF | HEDELEG_LPF | HEDELEG_SPF);
 
-    /**
-     * Start from a clean slate for the entire HENVCFG CSR
-     * to avoid unintended side effects from any non-zero default bits
+    /*
+     * Clean-slate the whole HENVCFG CSR (avoid stale default bits). It is a
+     * priv-1.12 CSR: on pre-1.12 cores (e.g. SiFive P550) it is absent and the
+     * access traps, so gate on the platform's RISCV_PRIV_VERSION.
      */
+#if RISCV_PRIV_VERSION >= RISCV_PRIV_VERSION_1_12
     csrs_henvcfg_write(0);
+#endif
 
     /**
      * Enable and sanity check presence of Sstc extension if the hypervisor was
@@ -42,8 +45,6 @@ void vmm_arch_init()
         // Set stimecmp to infinity in case we enable the stimer interrupt somewhere else
         // and fail to set the timer to a point in the future.
         csrs_stimecmp_write(~0ULL);
-    } else {
-        csrs_henvcfg_clear(HENVCFG_STCE);
     }
 
     if (CPU_HAS_EXTENSION(CPU_EXT_SVPBMT)) {

--- a/src/platform/milkv-megrez/inc/plat/cpu_ext.h
+++ b/src/platform/milkv-megrez/inc/plat/cpu_ext.h
@@ -1,0 +1,21 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved
+ */
+
+#ifndef __PLAT_CPU_EXT_H__
+#define __PLAT_CPU_EXT_H__
+
+/*
+ * EIC7700X: 4x SiFive P550, riscv,isa =
+ * "rv64imafdch_zicsr_zifencei_zba_zbb_sscofpmf" (vendor DT). Define only the
+ * tracked extensions the P550 has. The critical absentee is Sstc: no stimecmp,
+ * and the envcfg CSRs are pre-1.12 so they trap (see RISCV_PRIV_VERSION).
+ * Svpbmt/Zicbom/Zicboz/V/Smstateen/AIA/Sdtrig are also absent and left
+ * undefined (CPU_HAS_EXTENSION -> 0).
+ */
+#define CPU_EXT_SSTC 0
+
+#define CPU_EXT_F    1 /* f+d: guests use the FPU; Bao enables FS in (v)sstatus */
+
+#endif

--- a/src/platform/milkv-megrez/inc/plat/platform.h
+++ b/src/platform/milkv-megrez/inc/plat/platform.h
@@ -1,0 +1,26 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved
+ */
+
+#ifndef __PLAT_PLATFORM_H__
+#define __PLAT_PLATFORM_H__
+
+#include <plat/cpu_ext.h>
+
+/*
+ * The EIC7700X serial ports are Synopsys DesignWare APB UARTs:
+ *   reg-io-width = <4>  -> 32-bit register accesses
+ *   reg-shift    = <2>  -> registers are 4 bytes apart
+ *   (registers start at the page base, so no UART8250_PAGE_OFFSET)
+ * Must be defined before including the driver header, which derives
+ * uart8250_reg_t from it.
+ */
+#define UART8250_REG_WIDTH (4)
+
+#include <drivers/8250_uart.h>
+
+#define IPIC_SBI    (1)
+#define IPIC_ACLINT (2)
+
+#endif /* __PLAT_PLATFORM_H__ */

--- a/src/platform/milkv-megrez/megrez_desc.c
+++ b/src/platform/milkv-megrez/megrez_desc.c
@@ -1,0 +1,49 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <platform.h>
+#include <interrupts.h>
+
+/*
+ * Milk-V Megrez -- ESWIN EIC7700X, 4x SiFive P550 (rv64imafdch + Sscofpmf).
+ * Main DRAM: 16 GiB at 0x80000000 .. 0x480000000.
+ *
+ * The three managed regions respect the board DTS `reserved-memory` no-map
+ * carveouts: the three 4 KiB G2D boundary pages just below the 4/8/12 GiB marks
+ * (the G2D engine cannot cross a 4 GiB boundary) and the top-6 GiB vendor "mmz"
+ * pool at 0x300000000. They start 2 MiB above the DRAM base, above the vendor
+ * OpenSBI -- Bao must also be loaded there (set FW_JUMP / the U-Boot load
+ * address to match). ~10 GiB usable.
+ */
+
+#define MEGREZ_RAM_BASE (0x80200000) /* 2 MiB above DRAM base: skip vendor OpenSBI */
+
+struct platform platform = {
+
+    .cpu_num = 4,
+
+    .region_num = 3,
+    .regions = (struct mem_region[]) {
+        /* DRAM base .. below the 4 GiB G2D boundary page */
+        { .base = MEGREZ_RAM_BASE, .size = 0xFFFFF000 - MEGREZ_RAM_BASE },  /* ~2.0 GiB */
+        /* 4 GiB .. below the 8 GiB G2D boundary page */
+        { .base = 0x100000000,     .size = 0x1FFFFF000 - 0x100000000     }, /* ~4.0 GiB */
+        /* 8 GiB .. below the 12 GiB G2D page; vendor mmz reserves 0x300000000+ */
+        { .base = 0x200000000,     .size = 0x2FFFFF000 - 0x200000000     }, /* ~4.0 GiB */
+    },
+
+    .console = {
+        /* serial0 (chosen/stdout-path): DW-APB UART @ 0x50900000 */
+        .base = 0x50900000,
+    },
+
+    .arch = {
+        /* sifive,plic-1.0.0 (ndev 520, qemu-virt-compatible context layout) */
+        .irqc.plic.base = 0xc000000,
+
+        /* IPIC_SBI + no Sstc: IPIs and timer go via SBI, no aclint_sswi.base */
+    },
+
+};

--- a/src/platform/milkv-megrez/objects.mk
+++ b/src/platform/milkv-megrez/objects.mk
@@ -1,0 +1,4 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+boards-objs-y+=megrez_desc.o

--- a/src/platform/milkv-megrez/platform.mk
+++ b/src/platform/milkv-megrez/platform.mk
@@ -1,0 +1,25 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+## Milk-V Megrez / ESWIN EIC7700X (4x SiFive P550, RV64GC + H)
+
+# Architecture definition
+ARCH:=riscv
+# CPU definition (riscv march is set by the arch makefile; no -mtune needed)
+CPU:=
+# Interrupt controller definition: sifive,plic-1.0.0
+IRQC:=PLIC
+# Core IPIs controller: the EIC7700X exposes no ACLINT SSWI node, so route IPIs
+# through SBI
+IPIC:=IPIC_SBI
+# SiFive P550 is pre-1.12 (OpenSBI reports priv v1.11); no envcfg CSRs.
+RISCV_PRIV_VERSION := RISCV_PRIV_VERSION_1_11
+# The EIC7700X UARTs are Synopsys DesignWare APB blocks, which are 8250-compatible.
+drivers := 8250_uart
+
+platform_description:=megrez_desc.c
+
+platform-cppflags =-DIPIC=$(IPIC)
+platform-cflags =
+platform-asflags =
+platform-ldflags =


### PR DESCRIPTION
…eeds them

vmm_arch_init() unconditionally writes henvcfg (clean-slate write plus the STCE clear on the no-Sstc path) and vcpu init unconditionally writes senvcfg. Both are priv-1.12 CSRs: on cores that implement the H extension but predate priv 1.12 they are absent, and the access traps with illegal instruction. Since illegal instruction is not delegated, the trap bounces through M-mode back into the hypervisor's own exception path before any vcpu exists, wedging every hart right after the Bao banner.

Observed on the SiFive P550 (ESWIN EIC7700X / Milk-V Megrez, OpenSBI reports "Priv Version: v1.11", H present): boot wedges with either CSR access present and succeeds with both guarded. QEMU implements both CSRs and does not reproduce this.

Gate the accesses on the platform declaring at least one extension whose state lives in the respective CSR (Sstc, Svpbmt, Zicboz, Zicbom), following the existing CPU_HAS_EXTENSION() pattern. No behavior change on platforms that declare any of them.