### PR TITLE
fix(riscv): delegate breakpoint exceptions to the guest

### DIFF
--- a/src/arch/riscv/vmm.c
+++ b/src/arch/riscv/vmm.c
@@ -20,7 +20,7 @@ void vmm_arch_init()
      */
 
     csrs_hideleg_write(HIDELEG_VSSI | HIDELEG_VSTI | HIDELEG_VSEI);
-    csrs_hedeleg_write(HEDELEG_ECU | HEDELEG_IPF | HEDELEG_LPF | HEDELEG_SPF);
+    csrs_hedeleg_write(HEDELEG_BKP | HEDELEG_ECU | HEDELEG_IPF | HEDELEG_LPF | HEDELEG_SPF);
 
     /**
      * Start from a clean slate for the entire HENVCFG CSR


### PR DESCRIPTION
Guest breakpoint traps (scause 3) are not delegated, so a single ebreak executed by a guest -- including unprivileged userspace -- lands in Bao's sync_handler_table, which has no entry for it:

  BAO ERROR: unknown synchronous exception (3)

and the trapping hart is parked, permanently freezing the guest's vcpu. Reproduced on the Milk-V Megrez (EIC7700X) with a one-line userspace ebreak in a guest; other VMs keep running but the victim VM never recovers.

Breakpoint semantics belong to the guest: Linux implements BUG() and WARN() via ebreak, and debuggers plant ebreak for every breakpoint, so without delegation any guest kernel warning or gdb session kills the vcpu. Delegate HEDELEG_BKP so the guest kernel handles its own breakpoints (SIGTRAP delivery, WARN backtraces), as the existing TODO in vmm_arch_init already suggests.