### PR TITLE
feat(plat): add Agilex5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ platforms is presented below:
 - [x] Toradex Verdin iMX8M Plus (w/ Dahlia Carrier Board)
 - [x] NXP S32G3
 - [x] NXP iMX8M Nano EVK
+- [x] Altera Agilex 5 SoC FPGA
 
 **Armv7-A / Armv8-A AArch32**
 - [x] Arm Fixed Virtual Platforms

--- a/src/platform/agilex5/agilex5_desc.c
+++ b/src/platform/agilex5/agilex5_desc.c
@@ -1,0 +1,60 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#include <platform.h>
+
+/* Board DDR map. Capacity is injected as AGX5_MEM_GB via platform-cppflags
+ * (-DAGX5_MEM_GB, see platform.mk) and is common across all Agilex5 boards.
+ * Capacities > 2 GiB add a second mem_region for the high DDR window.
+ */
+#define AGX5_GB        (0x40000000ULL)
+#define AGX5_LOW_BASE  (0x82000000ULL)
+#define AGX5_LOW_RSVD  (AGX5_LOW_BASE - 0x80000000ULL)
+#define AGX5_HIGH_BASE (0x880000000ULL)
+
+/* GiB owned by each window for the requested capacity. */
+#define AGX5_LOW_GB    ((AGX5_MEM_GB) >= 2 ? 2ULL : (AGX5_MEM_GB))
+#define AGX5_HIGH_GB   ((AGX5_MEM_GB) > 2 ? ((AGX5_MEM_GB) - 2ULL) : 0ULL)
+
+struct platform platform = {
+    .cpu_num = 4,
+    .arch = {
+        .clusters = {
+            .num = 1,
+            .core_num = (size_t[]){ 4 },
+        },
+        .gic = {
+            .gicc_addr = 0x0,
+            .gich_addr = 0x0,
+            .gicv_addr = 0x0,
+            .gicd_addr = 0x1d000000,
+            .gicr_addr = 0x1d060000,
+            .maintenance_id = 25,
+        },
+        .generic_timer = {
+            .base_addr = 0x10d02000,
+        },
+    },
+    .region_num = (AGX5_MEM_GB > 2) ? 2 : 1,
+    .regions = (struct mem_region[]) {
+        {
+            /* Low window @ 0x82000000, capped at 2 GiB minus the 32 MiB
+             * TF-A/stub reservation. For AGX5_MEM_GB=2 this is 0x7e000000.
+             */
+            .base = AGX5_LOW_BASE,
+            .size = (AGX5_LOW_GB * AGX5_GB) - AGX5_LOW_RSVD,
+        },
+        {
+            /* High window @ 0x880000000 = capacity above 2 GiB.
+             * Only used when region_num == 2 (AGX5_MEM_GB > 2).
+             */
+            .base = AGX5_HIGH_BASE,
+            .size = AGX5_HIGH_GB * AGX5_GB,
+        },
+    },
+    .console = {
+        .base = 0x10c02000,
+    },
+};

--- a/src/platform/agilex5/inc/plat/platform.h
+++ b/src/platform/agilex5/inc/plat/platform.h
@@ -1,0 +1,16 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __PLAT_PLATFORM_H__
+#define __PLAT_PLATFORM_H__
+
+/* Agilex5 UART0: DesignWare 8250 (snps,dw-apb-uart) @ 0x10c02000, 32-bit
+ * registers (reg-shift=2, reg-io-width=4).
+ */
+#define UART8250_REG_WIDTH (4)
+
+#include <drivers/8250_uart.h>
+
+#endif /* __PLAT_PLATFORM_H__ */

--- a/src/platform/agilex5/inc/plat/psci.h
+++ b/src/platform/agilex5/inc/plat/psci.h
@@ -1,0 +1,22 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __PLAT_PSCI_H__
+#define __PLAT_PSCI_H__
+
+#define PSCI_POWER_STATE_LVL_0            0x0000000
+#define PSCI_POWER_STATE_LVL_1            0x1000000
+#define PSCI_POWER_STATE_LVL_2            0x2000000
+#define PSCI_STATE_TYPE_STANDBY           0x00000
+#define PSCI_STATE_TYPE_POWERDOWN         (1UL << 30)
+#define PSCI_STATE_TYPE_BIT               (1UL << 30)
+
+/* Agilex5 TF-A rejects PSCI_CPU_SUSPEND (returns INVALID_PARAMS) for both
+ * standby and powerdown, so route Bao's standby/powerdown through WFI.
+ */
+#define PLAT_PSCI_POWERDOWN_NOT_SUPPORTED 1
+#define PLAT_PSCI_STANDBY_NOT_SUPPORTED   1
+
+#endif /* __PLAT_PSCI_H__ */

--- a/src/platform/agilex5/objects.mk
+++ b/src/platform/agilex5/objects.mk
@@ -1,0 +1,3 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+boards-objs-y+=agilex5_desc.o

--- a/src/platform/agilex5/platform.mk
+++ b/src/platform/agilex5/platform.mk
@@ -1,0 +1,22 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+# Architecture definition
+ARCH:=armv8
+# big.LITTLE (2x A76 + 2x A55); tune for A55 as the common baseline
+CPU:=cortex-a55
+
+GIC_VERSION:=GICV3
+
+# Board DDR capacity in GiB; selects mem_regions in agilex5_desc.c.
+# Override via configs/<CONFIG>/config.mk or the make command line.
+AGX5_MEM_GB ?= 2
+
+drivers = 8250_uart
+
+platform_description:=agilex5_desc.c
+
+platform-cppflags = -DAGX5_MEM_GB=$(AGX5_MEM_GB)
+platform-cflags = -mtune=$(CPU)
+platform-asflags =
+platform-ldflags =


### PR DESCRIPTION
Add support for the Altera Agilex 5 SoC FPGA (HPS: 2x Cortex-A76 + 2x Cortex-A55), covering the GICv3, DDR memory map (sized via AGX5_MEM_GB), 8250 UART console and generic timer.

Depends on https://github.com/bao-project/bao-hypervisor/pull/338