### PR TITLE
feat(armv8/iommu): add SMMUv3 stage-2 driver

### DIFF
--- a/src/arch/armv8/arch.mk
+++ b/src/arch/armv8/arch.mk
@@ -17,6 +17,11 @@ arch_profile_sub_dir:=$(arch_profile_dir)/$(ARCH_SUB)
 src_dirs+=$(arch_profile_sub_dir)
 
 arch-cppflags+=-DGIC_VERSION=$(GIC_VERSION)
+
+# Default to SMMUv2 so platforms that don't care about the IOMMU (or predate
+# the v2/v3 split) keep compiling. Platforms select v3 in their platform.mk.
+SMMU_VERSION?=2
+arch-cppflags+=-DSMMU_VERSION=$(SMMU_VERSION)
 ifeq ($(CC_IS_GCC),y)
 arch-cflags+=-mgeneral-regs-only
 endif

--- a/src/arch/armv8/armv8-a/inc/arch/iommu.h
+++ b/src/arch/armv8/armv8-a/inc/arch/iommu.h
@@ -7,11 +7,23 @@
 #define __IOMMU_ARCH_H__
 
 #include <bao.h>
-#include <arch/smmuv2.h>
+#include <arch/smmu.h>
 
+#if (SMMU_VERSION == 3)
+/*
+ * SMMUv3 is stage-2-only here: each bound stream gets a Stream Table Entry that
+ * points directly at the VM's stage-2 page table (vm->as.pt.root) tagged with
+ * the VM's id as S2VMID. No per-VM context banks, so the only per-VM state we
+ * track is whether the STE(s) have been installed.
+ */
+struct iommu_vm_arch {
+    bool initialized;
+};
+#else
 struct iommu_vm_arch {
     streamid_t global_mask;
     ssize_t ctx_id;
 };
+#endif
 
 #endif

--- a/src/arch/armv8/armv8-a/inc/arch/smmu.h
+++ b/src/arch/armv8/armv8-a/inc/arch/smmu.h
@@ -1,0 +1,21 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ */
+
+#ifndef __ARCH_SMMU_H__
+#define __ARCH_SMMU_H__
+
+/*
+ * Version-selecting shim. The platform's SMMU_VERSION (default 2, see
+ * arch/armv8/arch.mk) picks the concrete driver header. Both headers must
+ * provide `typedef deviceid_t streamid_t;` so the generic platform/vm/iommu
+ * structures compile regardless of the selected version.
+ */
+#if (SMMU_VERSION == 3)
+#include <arch/smmuv3.h>
+#else
+#include <arch/smmuv2.h>
+#endif
+
+#endif /* __ARCH_SMMU_H__ */

--- a/src/arch/armv8/armv8-a/inc/arch/smmuv3.h
+++ b/src/arch/armv8/armv8-a/inc/arch/smmuv3.h
@@ -1,0 +1,210 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ *
+ * Minimal ARM SMMUv3 (IHI 0070) driver interface for Bao.
+ *
+ * Scope: stage-2-only translation. Bao owns stage 2 (the VM's IPA->PA page
+ * table); stage 1 is disabled (VMs see no SMMU). The driver installs a linear
+ * stream table, a command queue and an event queue, leaves every stream in
+ * BYPASS by default (so masters the firmware set up keep working unchanged),
+ * and promotes individual streams to stage-2 translation when a VM binds them.
+ *
+ * Register layout and field encodings follow the ARM SMMUv3 architecture
+ * specification (IHI 0070).
+ */
+
+#ifndef __ARCH_SMMUV3_H__
+#define __ARCH_SMMUV3_H__
+
+#include <bao.h>
+#include <bit.h>
+
+typedef deviceid_t streamid_t;
+
+/* ----------------------------------------------------------------------- */
+/* Non-secure register page (offsets from platform.arch.smmu.base)          */
+/* ----------------------------------------------------------------------- */
+
+struct smmuv3_hw {
+    uint32_t IDR0;            /* +0x0000 */
+    uint32_t IDR1;            /* +0x0004 */
+    uint32_t IDR2;            /* +0x0008 */
+    uint32_t IDR3;            /* +0x000C */
+    uint32_t IDR4;            /* +0x0010 */
+    uint32_t IDR5;            /* +0x0014 */
+    uint32_t IIDR;            /* +0x0018 */
+    uint32_t AIDR;            /* +0x001C */
+    uint32_t CR0;             /* +0x0020 */
+    uint32_t CR0ACK;          /* +0x0024 */
+    uint32_t CR1;             /* +0x0028 */
+    uint32_t CR2;             /* +0x002C */
+    uint8_t pad0[0x40 - 0x30];
+    uint32_t STATUSR;         /* +0x0040 */
+    uint32_t GBPA;            /* +0x0044 */
+    uint32_t AGBPA;           /* +0x0048 */
+    uint8_t pad1[0x50 - 0x4C];
+    uint32_t IRQ_CTRL;        /* +0x0050 */
+    uint32_t IRQ_CTRLACK;     /* +0x0054 */
+    uint8_t pad2[0x60 - 0x58];
+    uint32_t GERROR;          /* +0x0060 */
+    uint32_t GERRORN;         /* +0x0064 */
+    uint64_t GERROR_IRQ_CFG0; /* +0x0068 */
+    uint32_t GERROR_IRQ_CFG1; /* +0x0070 */
+    uint32_t GERROR_IRQ_CFG2; /* +0x0074 */
+    uint8_t pad3[0x80 - 0x78];
+    uint64_t STRTAB_BASE;     /* +0x0080 */
+    uint32_t STRTAB_BASE_CFG; /* +0x0088 */
+    uint8_t pad4[0x90 - 0x8C];
+    uint64_t CMDQ_BASE;       /* +0x0090 */
+    uint32_t CMDQ_PROD;       /* +0x0098 */
+    uint32_t CMDQ_CONS;       /* +0x009C */
+    uint64_t EVENTQ_BASE;     /* +0x00A0 */
+    uint32_t EVENTQ_PROD;     /* +0x00A8 (alias of page-1 PROD) */
+    uint32_t EVENTQ_CONS;     /* +0x00AC (alias of page-1 CONS) */
+};
+
+/* Every register is at its natural alignment, so the struct is NOT packed
+ * (packing would force -Waddress-of-packed-member on the &reg poll helpers).
+ * Guard the hand-computed offsets so a layout slip is caught at compile time. */
+_Static_assert(__builtin_offsetof(struct smmuv3_hw, CR0) == 0x20, "smmuv3 CR0 offset");
+_Static_assert(__builtin_offsetof(struct smmuv3_hw, GBPA) == 0x44, "smmuv3 GBPA offset");
+_Static_assert(__builtin_offsetof(struct smmuv3_hw, STRTAB_BASE) == 0x80,
+    "smmuv3 STRTAB_BASE offset");
+_Static_assert(__builtin_offsetof(struct smmuv3_hw, CMDQ_BASE) == 0x90, "smmuv3 CMDQ_BASE offset");
+_Static_assert(__builtin_offsetof(struct smmuv3_hw, EVENTQ_PROD) == 0xA8,
+    "smmuv3 EVENTQ_PROD offset");
+
+/* SMMU_IDR0 */
+#define SMMUV3_IDR0_ST_LEVEL_OFF (27)
+#define SMMUV3_IDR0_ST_LEVEL_LEN (2)
+#define SMMUV3_IDR0_COHACC_BIT   (1U << 4)
+#define SMMUV3_IDR0_VMID16_BIT   (1U << 18)
+#define SMMUV3_IDR0_TTF_OFF      (2)
+#define SMMUV3_IDR0_TTF_LEN      (2)
+#define SMMUV3_IDR0_S2P_BIT      (1U << 0)
+
+/* SMMU_IDR1 */
+#define SMMUV3_IDR1_SIDSIZE_OFF  (0)
+#define SMMUV3_IDR1_SIDSIZE_LEN  (6)
+
+/* SMMU_IDR5 */
+#define SMMUV3_IDR5_OAS_OFF      (0)
+#define SMMUV3_IDR5_OAS_LEN      (3)
+#define SMMUV3_IDR5_GRAN4K_BIT   (1U << 4)
+
+/* SMMU_CR0 / CR0ACK */
+#define SMMUV3_CR0_SMMUEN        (1U << 0)
+#define SMMUV3_CR0_EVENTQEN      (1U << 2)
+#define SMMUV3_CR0_CMDQEN        (1U << 3)
+
+/* SMMU_CR1 cacheability/shareability for table & queue accesses */
+#define SMMUV3_CR1_INSH          (0x3) /* inner shareable */
+#define SMMUV3_CR1_WBCACHE       (0x1) /* normal WB cacheable */
+#define SMMUV3_CR1_DEFAULT                                   \
+    ((SMMUV3_CR1_INSH << 10) | (SMMUV3_CR1_WBCACHE << 8) |   \
+        (SMMUV3_CR1_WBCACHE << 6) |    /* table: SH/OC/IC */ \
+        (SMMUV3_CR1_INSH << 4) | (SMMUV3_CR1_WBCACHE << 2) | (SMMUV3_CR1_WBCACHE)) /* queue */
+
+/* SMMU_GBPA */
+#define SMMUV3_GBPA_UPDATE                  (1U << 31)
+#define SMMUV3_GBPA_ABORT                   (1U << 20)
+
+/* SMMU_IRQ_CTRL / _CTRLACK (wired-SPI delivery of fault interrupts) */
+#define SMMUV3_IRQ_CTRL_GERROR              (1U << 0)
+#define SMMUV3_IRQ_CTRL_PRIQ                (1U << 1)
+#define SMMUV3_IRQ_CTRL_EVENTQ              (1U << 2)
+
+/* SMMU_STRTAB_BASE / _CFG */
+#define SMMUV3_STRTAB_BASE_RA               (1ULL << 62)
+#define SMMUV3_STRTAB_BASE_ADDR_MASK        BIT64_MASK(6, 46)
+#define SMMUV3_STRTAB_BASE_CFG_FMT_LINEAR   (0x0U << 16)
+#define SMMUV3_STRTAB_BASE_CFG_LOG2SIZE_OFF (0)
+
+/* SMMU_CMDQ_BASE / EVENTQ_BASE */
+#define SMMUV3_Q_BASE_RA                    (1ULL << 62)
+#define SMMUV3_Q_BASE_ADDR_MASK             BIT64_MASK(5, 47)
+#define SMMUV3_Q_BASE_LOG2SIZE_MASK         (0x1FULL)
+/* PROD/CONS wrap bit sits just above the index field */
+#define SMMUV3_Q_WRAP(log2size)             (1U << (log2size))
+#define SMMUV3_Q_IDX_MASK(log2size)         (SMMUV3_Q_WRAP(log2size) - 1U)
+
+/* ----------------------------------------------------------------------- */
+/* Stream Table Entry (8 x 64-bit). Stage-2-only / bypass fields.           */
+/* Bit positions per ARM IHI 0070.                                          */
+/* ----------------------------------------------------------------------- */
+
+#define SMMUV3_STE_DWORDS                   (8)
+
+struct smmuv3_ste {
+    uint64_t data[SMMUV3_STE_DWORDS];
+} __attribute__((__aligned__(64)));
+
+/* word 0 */
+#define STE_W0_V                  (1ULL << 0)
+#define STE_W0_CONFIG_OFF         (1)
+#define STE_W0_CONFIG_BYPASS      (0x4ULL) /* S1 bypass, S2 bypass */
+#define STE_W0_CONFIG_S2          (0x6ULL) /* S1 bypass, S2 translate */
+
+/* word 1 (attribute overrides used in bypass STEs) */
+#define STE_W1_SHCFG_OFF          (44)
+#define STE_W1_SHCFG_USE_INCOMING (0x1ULL) /* pass master's shareability */
+
+/* word 2 (stage-2 config) */
+#define STE_W2_S2VMID_OFF         (0)
+#define STE_W2_S2T0SZ_OFF         (32)
+#define STE_W2_S2SL0_OFF          (38)
+#define STE_W2_S2IR0_OFF          (40)
+#define STE_W2_S2OR0_OFF          (42)
+#define STE_W2_S2SH0_OFF          (44)
+#define STE_W2_S2TG_OFF           (46)
+#define STE_W2_S2PS_OFF           (48)
+#define STE_W2_S2AA64             (1ULL << 51)
+#define STE_W2_S2AFFD             (1ULL << 53)
+#define STE_W2_S2R                (1ULL << 58) /* record stage-2 faults to evtq */
+#define STE_W2_WB                 (0x1ULL)     /* IR0/OR0: WB cacheable RA/WA */
+#define STE_W2_ISH                (0x3ULL)     /* SH0: inner shareable */
+#define STE_W2_TG_4K              (0x0ULL)
+
+/* word 3 stage-2 translation table base */
+#define STE_W3_S2TTB_MASK         BIT64_MASK(4, 48)
+
+/* ----------------------------------------------------------------------- */
+/* Command queue: 128-bit commands (2 x 64-bit).                            */
+/* ----------------------------------------------------------------------- */
+
+#define SMMUV3_CMDQ_ENT_DWORDS    (2)
+
+#define CMD_OP_CFGI_STE           (0x03ULL)
+#define CMD_OP_CFGI_STE_RANGE     (0x04ULL)
+#define CMD_OP_TLBI_S12_VMALL     (0x28ULL)
+#define CMD_OP_TLBI_NSNH_ALL      (0x30ULL)
+#define CMD_OP_SYNC               (0x46ULL)
+
+/* CMD_CFGI_STE / _RANGE: StreamID in [63:32] of dword0 */
+#define CMD_CFGI_SID_OFF          (32)
+#define CMD_CFGI_STE_LEAF         (1ULL << 0)  /* dword1 */
+#define CMD_CFGI_STE_RANGE_ALL    (31ULL << 0) /* dword1: Range=31 -> all */
+
+/* CMD_TLBI_S12_VMALL: VMID in [47:32] of dword0 */
+#define CMD_TLBI_VMID_OFF         (32)
+
+/* CMD_SYNC: CS (completion signal) = none; we poll CONS instead */
+#define CMD_SYNC_CS_NONE          (0x0ULL << 12)
+
+/* Event queue record: 4 x 64-bit. dword0 [7:0]=fault type, [63:32]=StreamID;
+ * dword2 = input (IPA) address for translation/permission faults. */
+#define SMMUV3_EVTQ_ENT_DWORDS    (4)
+#define SMMUV3_EVT_TYPE_MASK      (0xFFULL)
+#define SMMUV3_EVT_SID_OFF        (32)
+
+/* ----------------------------------------------------------------------- */
+/* Driver API (consumed by iommu.c).                                        */
+/* ----------------------------------------------------------------------- */
+
+void smmuv3_init(void);
+bool smmuv3_write_ste_s2(streamid_t sid, paddr_t root_pt, uint16_t vmid);
+bool smmuv3_write_ste_bypass(streamid_t sid);
+void smmuv3_poll_events(void); /* drain+log SMMU faults; safe before init */
+
+#endif                         /* __ARCH_SMMUV3_H__ */

--- a/src/arch/armv8/armv8-a/iommu.c
+++ b/src/arch/armv8/armv8-a/iommu.c
@@ -9,6 +9,67 @@
 #include <mem.h>
 #include <config.h>
 
+#if (SMMU_VERSION == 3)
+
+bool iommu_arch_init(void)
+{
+    if (cpu_is_master() && platform.arch.smmu.base) {
+        smmuv3_init();
+        return true;
+    }
+
+    return false;
+}
+
+/* Install a stage-2-only STE for every stream id covered by {mask, id}. */
+static bool iommu_vm_arch_add(struct vm* vm, streamid_t mask, streamid_t id)
+{
+    paddr_t rootpt;
+    mem_translate(&cpu()->as, (vaddr_t)vm->as.pt.root, &rootpt);
+
+    /*
+     * A zero mask is the common case (a single device). A non-zero mask means
+     * "every stream id that matches id under this mask" -- iterate the masked
+     * bits and bind each concrete stream id to the same stage-2 config. SMMUv3
+     * has a flat stream table (no stream-match registers), so we materialise
+     * one STE per id rather than relying on a hardware mask.
+     */
+    streamid_t base = id & (streamid_t)~mask;
+    for (streamid_t sub = 0;; sub++) {
+        streamid_t sid = base | (sub & mask);
+        if (!smmuv3_write_ste_s2(sid, rootpt, (uint16_t)vm->id)) {
+            return false;
+        }
+        if (sub == mask) {
+            break;
+        }
+    }
+
+    vm->io.prot.mmu.initialized = true;
+    return true;
+}
+
+bool iommu_arch_vm_add_device(struct vm* vm, streamid_t id)
+{
+    return iommu_vm_arch_add(vm, 0, id);
+}
+
+bool iommu_arch_vm_init(struct vm* vm, const struct vm_config* vm_config)
+{
+    vm->io.prot.mmu.initialized = false;
+
+    for (size_t i = 0; i < vm_config->platform.arch.smmu.group_num; i++) {
+        const struct smmu_group* group = &vm_config->platform.arch.smmu.groups[i];
+        if (!iommu_vm_arch_add(vm, group->mask, group->id)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+#else  /* SMMU_VERSION != 3 -> SMMUv2 */
+
 bool iommu_arch_init(void)
 {
     if (cpu_is_master() && platform.arch.smmu.base) {
@@ -86,3 +147,5 @@ bool iommu_arch_vm_init(struct vm* vm, const struct vm_config* vm_config)
 
     return true;
 }
+
+#endif /* SMMU_VERSION */

--- a/src/arch/armv8/armv8-a/objects.mk
+++ b/src/arch/armv8/armv8-a/objects.mk
@@ -7,7 +7,11 @@ cpu-objs-y+=$(ARCH_PROFILE)/mem.o
 cpu-objs-y+=$(ARCH_PROFILE)/vm.o
 cpu-objs-y+=$(ARCH_PROFILE)/vmm.o
 cpu-objs-y+=$(ARCH_PROFILE)/psci.o
+ifeq ($(SMMU_VERSION), 3)
+cpu-objs-y+=$(ARCH_PROFILE)/smmuv3.o
+else
 cpu-objs-y+=$(ARCH_PROFILE)/smmuv2.o
+endif
 cpu-objs-y+=$(ARCH_PROFILE)/iommu.o
 cpu-objs-y+=$(ARCH_PROFILE)/cpu.o
 cpu-objs-y+=$(ARCH_PROFILE)/smc.o

--- a/src/arch/armv8/armv8-a/smmuv3.c
+++ b/src/arch/armv8/armv8-a/smmuv3.c
@@ -1,0 +1,458 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Bao Project and Contributors. All rights reserved.
+ *
+ * Minimal ARM SMMUv3 (IHI 0070) driver for Bao — stage-2-only.
+ *
+ * See arch/smmuv3.h for the design summary. The driver takes over the live
+ * non-secure SMMU that firmware (TF-A) leaves enabled: it installs its own
+ * linear stream table (all entries BYPASS so masters keep working with their
+ * incoming attributes, matching the firmware handoff), command queue and event
+ * queue, then promotes individual streams to stage-2 translation as VMs bind
+ * them.
+ */
+
+#include <arch/smmuv3.h>
+#include <arch/spinlock.h>
+#include <arch/fences.h>
+#include <arch/page_table.h>
+#include <platform.h>
+#include <cpu.h>
+#include <mem.h>
+#include <cache.h>
+#include <string.h>
+#include <bit.h>
+#include <interrupts.h>
+
+/* Linear stream table cap: 2^SMMUV3_ST_LOG2_CAP entries (default 2^8 = 256,
+ * 16 KiB). A platform whose stream-ID space is sparse or starts high can
+ * override this from its platform.mk (e.g. -DSMMUV3_ST_LOG2_CAP=11). */
+#ifndef SMMUV3_ST_LOG2_CAP
+#define SMMUV3_ST_LOG2_CAP (8)
+#endif
+#define SMMUV3_CMDQ_LOG2SIZE (7) /* 128 entries x 16 B = 2 KiB */
+#define SMMUV3_EVTQ_LOG2SIZE (7) /* 128 entries x 32 B = 4 KiB */
+
+#define SMMUV3_POLL_LIMIT    (1000000)
+
+struct smmuv3_priv {
+    volatile struct smmuv3_hw* hw;
+
+    struct smmuv3_ste* st;
+    size_t st_log2size;
+    size_t st_entries;
+
+    uint64_t* cmdq;
+    uint32_t cmdq_prod; /* raw producer counter, modulo 2*size */
+
+    uint64_t* evtq;
+    /* EVENTQ producer/consumer indices live in SMMU page 1 (offset 0x10000); the
+     * page-0 0xA8/0xAC copies are RAZ/WI aliases on real silicon. */
+    volatile uint32_t* evtq_prod;
+    volatile uint32_t* evtq_cons;
+
+    bool coherent;       /* SMMU performs coherent table/queue accesses */
+    volatile bool ready; /* published last; gates the poll hook (see below) */
+    spinlock_t lock;
+};
+
+/* Deliberately a single global instance: this driver assumes one SMMU per SoC.
+ * A streamID is only unique within a given instance's stream table, so adding
+ * multi-SMMU support later means threading a per-group "which SMMU" selector
+ * through struct smmu_group (arch/vm.h) down to here. Kept single for now. */
+
+#define SMMUV3_PAGE1_OFF         (0x10000UL)
+#define SMMUV3_PAGE1_EVENTQ_PROD (SMMUV3_PAGE1_OFF + 0xA8UL)
+#define SMMUV3_PAGE1_EVENTQ_CONS (SMMUV3_PAGE1_OFF + 0xACUL)
+
+static struct smmuv3_priv smmu;
+
+/* Clean (and on non-coherent SMMUs, flush) a structure we wrote so the SMMU's
+ * table/queue walk observes it. On coherent SMMUs a barrier is enough. */
+static inline void smmuv3_push(vaddr_t addr, size_t size)
+{
+    if (smmu.coherent) {
+        fence_sync_write();
+    } else {
+        cache_flush_range(addr, size);
+    }
+}
+
+static int smmuv3_poll(volatile uint32_t* reg, uint32_t mask, uint32_t val)
+{
+    for (size_t i = 0; i < SMMUV3_POLL_LIMIT; i++) {
+        if ((*reg & mask) == val) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static void smmuv3_check_features(void)
+{
+    uint32_t aidr = smmu.hw->AIDR & 0xF;
+    if (aidr > 2) {
+        WARNING("smmuv3: unexpected arch version AIDR=0x%x", aidr);
+    }
+
+    if (!(smmu.hw->IDR0 & SMMUV3_IDR0_S2P_BIT)) {
+        ERROR("smmuv3 does not support stage-2 translation");
+    }
+
+    if (!(smmu.hw->IDR5 & SMMUV3_IDR5_GRAN4K_BIT)) {
+        ERROR("smmuv3 does not support 4kb granule");
+    }
+
+    size_t oas = bit32_extract(smmu.hw->IDR5, SMMUV3_IDR5_OAS_OFF, SMMUV3_IDR5_OAS_LEN);
+    if (oas < parange) {
+        ERROR("smmuv3 OAS (%d) smaller than platform parange (%d)", oas, parange);
+    }
+}
+
+/* Push a 128-bit command into the queue and advance the producer index. The
+ * caller must hold smmu.lock. */
+static void smmuv3_cmdq_push(uint64_t dword0, uint64_t dword1)
+{
+    size_t idx = smmu.cmdq_prod & SMMUV3_Q_IDX_MASK(SMMUV3_CMDQ_LOG2SIZE);
+    smmu.cmdq[idx * SMMUV3_CMDQ_ENT_DWORDS] = dword0;
+    smmu.cmdq[idx * SMMUV3_CMDQ_ENT_DWORDS + 1] = dword1;
+    smmuv3_push((vaddr_t)&smmu.cmdq[idx * SMMUV3_CMDQ_ENT_DWORDS],
+        SMMUV3_CMDQ_ENT_DWORDS * sizeof(uint64_t));
+
+    /* Producer counter is kept modulo 2*size so its low (log2size+1) bits are
+     * exactly the {WRAP, INDEX} encoding the hardware expects. */
+    smmu.cmdq_prod = (smmu.cmdq_prod + 1) & ((SMMUV3_Q_WRAP(SMMUV3_CMDQ_LOG2SIZE) << 1) - 1);
+    fence_sync_write();
+    smmu.hw->CMDQ_PROD = smmu.cmdq_prod;
+}
+
+/* Issue CMD_SYNC and wait for the command queue to drain. */
+static void smmuv3_cmdq_sync(void)
+{
+    smmuv3_cmdq_push(CMD_OP_SYNC | CMD_SYNC_CS_NONE, 0);
+
+    /* Compare the full {WRAP, INDEX} field: masking only the index bits makes a
+     * completely full queue (PROD = CONS + size) indistinguishable from empty.
+     * cmdq_prod is kept modulo 2*size and hardware maintains the wrap bit in
+     * CMDQ_CONS, so the full-field compare is robust even under batching. */
+    uint32_t fullmask = (SMMUV3_Q_WRAP(SMMUV3_CMDQ_LOG2SIZE) << 1) - 1;
+    for (size_t i = 0; i < SMMUV3_POLL_LIMIT; i++) {
+        if ((smmu.hw->CMDQ_CONS & fullmask) == (smmu.cmdq_prod & fullmask)) {
+            return;
+        }
+    }
+    WARNING("smmuv3: CMD_SYNC timed out (CONS=0x%x PROD=0x%x)", smmu.hw->CMDQ_CONS, smmu.cmdq_prod);
+}
+
+static void smmuv3_cmdq_cfgi_ste(streamid_t sid)
+{
+    smmuv3_cmdq_push(CMD_OP_CFGI_STE | ((uint64_t)sid << CMD_CFGI_SID_OFF), CMD_CFGI_STE_LEAF);
+}
+
+static void smmuv3_cmdq_tlbi_vmid(uint16_t vmid)
+{
+    smmuv3_cmdq_push(CMD_OP_TLBI_S12_VMALL | ((uint64_t)vmid << CMD_TLBI_VMID_OFF), 0);
+}
+
+/* Populate an STE as BYPASS, passing the master's incoming attributes through
+ * unchanged (SHCFG=use-incoming). This deliberately does NOT override
+ * shareability/memory-type so that masters the firmware left in bypass behave
+ * exactly as before Bao touched the SMMU. */
+static void smmuv3_ste_fill_bypass(struct smmuv3_ste* e)
+{
+    memset(e, 0, sizeof(*e));
+    e->data[1] = STE_W1_SHCFG_USE_INCOMING << STE_W1_SHCFG_OFF;
+    fence_sync_write();
+    e->data[0] = STE_W0_V | (STE_W0_CONFIG_BYPASS << STE_W0_CONFIG_OFF);
+}
+
+/* Populate an STE as ABORT: an invalid STE (V=0) terminates any transaction
+ * from that stream and records a C_BAD_STE fault in the event queue, so an
+ * un-enumerated master is stopped instead of DMAing freely. */
+#ifdef SMMUV3_DEFAULT_ABORT
+static void smmuv3_ste_fill_abort(struct smmuv3_ste* e)
+{
+    memset(e, 0, sizeof(*e)); /* V=0 -> abort + fault record */
+}
+#endif
+
+/* Default STE for streams no VM has bound. BYPASS by default so the firmware
+ * handoff stays transparent (masters keep working with incoming attributes). A
+ * platform with a fully-known streamID map can flip the default to ABORT --
+ * turning the SMMU into an isolation boundary -- via -DSMMUV3_DEFAULT_ABORT in
+ * its platform.mk. Note this only changes the unbound default; GBPA is kept in
+ * BYPASS during the reconfiguration window regardless (see smmuv3_init), so
+ * in-flight transactions during handoff never fault. */
+static void smmuv3_ste_fill_default(struct smmuv3_ste* e)
+{
+#ifdef SMMUV3_DEFAULT_ABORT
+    smmuv3_ste_fill_abort(e);
+#else
+    smmuv3_ste_fill_bypass(e);
+#endif
+}
+
+/* Drain + log the event queue. Each record is a translation/permission/etc.
+ * fault: a DMA the SMMU refused. On a correctly-bound, well-behaved system this
+ * stays empty; any line here is a master accessing memory it isn't allowed to
+ * (the IOMMU doing its job) -- so we surface it loudly. Caller holds smmu.lock. */
+static void smmuv3_drain_events(void)
+{
+    uint32_t wrapmask = (SMMUV3_Q_WRAP(SMMUV3_EVTQ_LOG2SIZE) << 1) - 1;
+    uint32_t idxmask = SMMUV3_Q_IDX_MASK(SMMUV3_EVTQ_LOG2SIZE);
+    uint32_t prod = *smmu.evtq_prod & wrapmask;
+    uint32_t cons = *smmu.evtq_cons & wrapmask;
+
+    while (cons != prod) {
+        uint64_t* e = &smmu.evtq[(cons & idxmask) * SMMUV3_EVTQ_ENT_DWORDS];
+        if (!smmu.coherent) {
+            cache_flush_range((vaddr_t)e, SMMUV3_EVTQ_ENT_DWORDS * sizeof(uint64_t));
+        }
+        WARNING("smmuv3 FAULT: type=0x%x stream=%d addr=0x%lx [%lx %lx]",
+            (unsigned)(e[0] & SMMUV3_EVT_TYPE_MASK), (int)(e[0] >> SMMUV3_EVT_SID_OFF),
+            (unsigned long)e[2], (unsigned long)e[0], (unsigned long)e[1]);
+        cons = (cons + 1) & wrapmask;
+    }
+    fence_sync_write();
+    *smmu.evtq_cons = cons;
+}
+
+static void smmuv3_eventq_irq_handler(irqid_t id)
+{
+    (void)id;
+    spin_lock(&smmu.lock);
+    smmuv3_drain_events();
+    spin_unlock(&smmu.lock);
+}
+
+/* Cheap poll hook called from the GIC IRQ path: if the SMMU event queue is
+ * non-empty, drain+log it. This makes faults visible even if the dedicated
+ * wired event IRQ isn't delivered. No-op until the driver is initialised. */
+void smmuv3_poll_events(void)
+{
+    if (!smmu.ready) {
+        return;
+    }
+    /* Acquire: order the ready load before the queue-state loads below. A
+     * control dependency alone doesn't order load->load on ARMv8, so without
+     * this a core that just saw ready==true could still read a stale evtq /
+     * PROD-CONS pair set up before the flag was published. Pairs with the
+     * release barrier before "smmu.ready = true" in smmuv3_init(). */
+    fence_ord_read();
+    uint32_t wrapmask = (SMMUV3_Q_WRAP(SMMUV3_EVTQ_LOG2SIZE) << 1) - 1;
+    if ((*smmu.evtq_prod & wrapmask) == (*smmu.evtq_cons & wrapmask)) {
+        return; /* empty -- common case, no lock taken */
+    }
+    spin_lock(&smmu.lock);
+    smmuv3_drain_events();
+    spin_unlock(&smmu.lock);
+}
+
+void smmuv3_init(void)
+{
+    smmu.lock = SPINLOCK_INITVAL;
+
+    /* Map page 0 (the registers in struct smmuv3_hw) AND page 1 (offset 0x10000,
+     * which holds the architectural EVENTQ_PROD/CONS). */
+    vaddr_t regs = mem_alloc_map_dev(&cpu()->as, SEC_HYP_GLOBAL, INVALID_VA,
+        platform.arch.smmu.base, NUM_PAGES(SMMUV3_PAGE1_EVENTQ_CONS + 4));
+    smmu.hw = (volatile struct smmuv3_hw*)regs;
+    smmu.evtq_prod = (volatile uint32_t*)(regs + SMMUV3_PAGE1_EVENTQ_PROD);
+    smmu.evtq_cons = (volatile uint32_t*)(regs + SMMUV3_PAGE1_EVENTQ_CONS);
+
+    smmu.coherent = (smmu.hw->IDR0 & SMMUV3_IDR0_COHACC_BIT) != 0;
+    smmuv3_check_features();
+
+    /* Linear stream table sized to min(SIDSIZE, cap). */
+    size_t sidsize = bit32_extract(smmu.hw->IDR1, SMMUV3_IDR1_SIDSIZE_OFF, SMMUV3_IDR1_SIDSIZE_LEN);
+    smmu.st_log2size = (sidsize < SMMUV3_ST_LOG2_CAP) ? sidsize : SMMUV3_ST_LOG2_CAP;
+    smmu.st_entries = 1UL << smmu.st_log2size;
+
+    size_t st_bytes = smmu.st_entries * sizeof(struct smmuv3_ste);
+    smmu.st =
+        (struct smmuv3_ste*)mem_alloc_page(NUM_PAGES(st_bytes), SEC_HYP_GLOBAL, MEM_ALIGN_REQ);
+    for (size_t i = 0; i < smmu.st_entries; i++) {
+        smmuv3_ste_fill_default(&smmu.st[i]);
+    }
+    smmuv3_push((vaddr_t)smmu.st, st_bytes);
+
+    /* Command queue + event queue. */
+    size_t cmdq_bytes = (1UL << SMMUV3_CMDQ_LOG2SIZE) * SMMUV3_CMDQ_ENT_DWORDS * sizeof(uint64_t);
+    smmu.cmdq = (uint64_t*)mem_alloc_page(NUM_PAGES(cmdq_bytes), SEC_HYP_GLOBAL, MEM_ALIGN_REQ);
+    memset(smmu.cmdq, 0, cmdq_bytes);
+    smmu.cmdq_prod = 0;
+
+    size_t evtq_bytes = (1UL << SMMUV3_EVTQ_LOG2SIZE) * SMMUV3_EVTQ_ENT_DWORDS * sizeof(uint64_t);
+    smmu.evtq = (uint64_t*)mem_alloc_page(NUM_PAGES(evtq_bytes), SEC_HYP_GLOBAL, MEM_ALIGN_REQ);
+    memset(smmu.evtq, 0, evtq_bytes);
+    smmuv3_push((vaddr_t)smmu.cmdq, cmdq_bytes);
+    smmuv3_push((vaddr_t)smmu.evtq, evtq_bytes);
+
+    paddr_t st_pa, cmdq_pa, evtq_pa;
+    mem_translate(&cpu()->as, (vaddr_t)smmu.st, &st_pa);
+    mem_translate(&cpu()->as, (vaddr_t)smmu.cmdq, &cmdq_pa);
+    mem_translate(&cpu()->as, (vaddr_t)smmu.evtq, &evtq_pa);
+
+    /* Quiesce the SMMU that firmware left enabled before re-pointing its tables.
+     * Keep GBPA in BYPASS (not ABORT) so that any in-flight transaction during
+     * the reconfiguration window passes through rather than faulting. */
+    smmu.hw->GBPA = SMMUV3_GBPA_UPDATE | (STE_W1_SHCFG_USE_INCOMING << 12);
+    if (smmuv3_poll(&smmu.hw->GBPA, SMMUV3_GBPA_UPDATE, 0) != 0) {
+        ERROR("smmuv3: GBPA update did not complete");
+    }
+    smmu.hw->CR0 = 0;
+    if (smmuv3_poll(&smmu.hw->CR0ACK, SMMUV3_CR0_SMMUEN | SMMUV3_CR0_CMDQEN | SMMUV3_CR0_EVENTQEN,
+            0) != 0) {
+        ERROR("smmuv3: failed to quiesce CR0");
+    }
+
+    /* Table/queue access attributes: inner-shareable, write-back cacheable. */
+    smmu.hw->CR1 = SMMUV3_CR1_DEFAULT;
+
+    smmu.hw->STRTAB_BASE = (st_pa & SMMUV3_STRTAB_BASE_ADDR_MASK) | SMMUV3_STRTAB_BASE_RA;
+    smmu.hw->STRTAB_BASE_CFG = SMMUV3_STRTAB_BASE_CFG_FMT_LINEAR | (uint32_t)smmu.st_log2size;
+
+    smmu.hw->CMDQ_BASE =
+        (cmdq_pa & SMMUV3_Q_BASE_ADDR_MASK) | SMMUV3_Q_BASE_RA | SMMUV3_CMDQ_LOG2SIZE;
+    smmu.hw->CMDQ_PROD = 0;
+    smmu.hw->CMDQ_CONS = 0;
+
+    smmu.hw->EVENTQ_BASE =
+        (evtq_pa & SMMUV3_Q_BASE_ADDR_MASK) | SMMUV3_Q_BASE_RA | SMMUV3_EVTQ_LOG2SIZE;
+    *smmu.evtq_prod = 0;
+    *smmu.evtq_cons = 0;
+    fence_sync_write();
+
+    /* Enable command processing, then event queue. */
+    smmu.hw->CR0 = SMMUV3_CR0_CMDQEN;
+    if (smmuv3_poll(&smmu.hw->CR0ACK, SMMUV3_CR0_CMDQEN, SMMUV3_CR0_CMDQEN) != 0) {
+        ERROR("smmuv3: CMDQEN not acknowledged");
+    }
+    smmu.hw->CR0 = SMMUV3_CR0_CMDQEN | SMMUV3_CR0_EVENTQEN;
+    if (smmuv3_poll(&smmu.hw->CR0ACK, SMMUV3_CR0_EVENTQEN, SMMUV3_CR0_EVENTQEN) != 0) {
+        ERROR("smmuv3: EVENTQEN not acknowledged");
+    }
+
+    /* Route the event-queue fault interrupt (wired SPI) to a handler that drains
+     * + logs faults, so a refused DMA is visible instead of silent. */
+    if (platform.arch.smmu.interrupt_id != 0) {
+        irqid_t eid =
+            interrupts_reserve(platform.arch.smmu.interrupt_id, smmuv3_eventq_irq_handler);
+        if (eid != INVALID_IRQID) {
+            interrupts_cpu_enable(eid, true);
+            smmu.hw->IRQ_CTRL = SMMUV3_IRQ_CTRL_EVENTQ | SMMUV3_IRQ_CTRL_GERROR;
+            if (smmuv3_poll(&smmu.hw->IRQ_CTRLACK, SMMUV3_IRQ_CTRL_EVENTQ,
+                    SMMUV3_IRQ_CTRL_EVENTQ) != 0) {
+                WARNING("smmuv3: IRQ_CTRL not acknowledged; fault IRQ may be inactive");
+            }
+        } else {
+            INFO("smmuv3: could not reserve event irq %d", platform.arch.smmu.interrupt_id);
+        }
+    }
+
+    /* Drop any stale config/TLB the SMMU cached from firmware's stream table. */
+    spin_lock(&smmu.lock);
+    smmuv3_cmdq_push(CMD_OP_CFGI_STE_RANGE, CMD_CFGI_STE_RANGE_ALL);
+    smmuv3_cmdq_push(CMD_OP_TLBI_NSNH_ALL, 0);
+    smmuv3_cmdq_sync();
+    spin_unlock(&smmu.lock);
+
+    /* Finally re-enable translation against our stream table. */
+    smmu.hw->CR0 = SMMUV3_CR0_CMDQEN | SMMUV3_CR0_EVENTQEN | SMMUV3_CR0_SMMUEN;
+    if (smmuv3_poll(&smmu.hw->CR0ACK, SMMUV3_CR0_SMMUEN, SMMUV3_CR0_SMMUEN) != 0) {
+        ERROR("smmuv3: SMMUEN not acknowledged");
+    }
+
+    /* Publish "ready" last, once SMMUEN is acked and everything the poll hook
+     * touches (evtq buffer, EVENTQ_BASE, the PROD/CONS pointers and their reset
+     * values) is live. Release barrier first so those prior stores are visible
+     * to any other core before it observes ready==true; the poll hook does the
+     * matching acquire. Without this a secondary CPU taking an IRQ mid-init
+     * could see ready==true while smmu.evtq is still NULL from its viewpoint. */
+    fence_ord_write();
+    smmu.ready = true;
+
+    INFO("smmuv3: enabled, %d stream-table entries, %s table walks", (int)smmu.st_entries,
+        smmu.coherent ? "coherent" : "non-coherent");
+}
+
+bool smmuv3_write_ste_bypass(streamid_t sid)
+{
+    if (sid >= smmu.st_entries) {
+        INFO("smmuv3: stream id %d exceeds stream table (%d entries)", sid, (int)smmu.st_entries);
+        return false;
+    }
+
+    spin_lock(&smmu.lock);
+    struct smmuv3_ste* e = &smmu.st[sid];
+    e->data[0] = 0; /* invalidate while we rewrite */
+    smmuv3_push((vaddr_t)e, sizeof(*e));
+    smmuv3_cmdq_cfgi_ste(sid);
+    smmuv3_cmdq_sync();
+
+    smmuv3_ste_fill_bypass(e);
+    smmuv3_push((vaddr_t)e, sizeof(*e));
+    smmuv3_cmdq_cfgi_ste(sid);
+    smmuv3_cmdq_sync();
+    spin_unlock(&smmu.lock);
+
+    return true;
+}
+
+bool smmuv3_write_ste_s2(streamid_t sid, paddr_t root_pt, uint16_t vmid)
+{
+    if (sid >= smmu.st_entries) {
+        INFO("smmuv3: stream id %d exceeds stream table (%d entries)", sid, (int)smmu.st_entries);
+        return false;
+    }
+
+    /* Stage-2 config mirrors the VTCR Bao programs for the VM's stage-2 page
+     * table (see vmm_arch_init / smmuv2 smmu_write_ctxbnk): same parange-derived
+     * T0SZ / start-level / PS so the SMMU walks the identical tables. */
+    size_t t0sz = 64 - parange_table[parange];
+    uint64_t sl0 = (parange_table[parange] < 44) ? 0x1ULL : 0x2ULL;
+    uint64_t ps = (uint64_t)parange;
+
+    uint64_t w2 = ((uint64_t)vmid << STE_W2_S2VMID_OFF) | ((uint64_t)t0sz << STE_W2_S2T0SZ_OFF) |
+        (sl0 << STE_W2_S2SL0_OFF) | (STE_W2_WB << STE_W2_S2IR0_OFF) |
+        (STE_W2_WB << STE_W2_S2OR0_OFF) | (STE_W2_ISH << STE_W2_S2SH0_OFF) |
+        (STE_W2_TG_4K << STE_W2_S2TG_OFF) | (ps << STE_W2_S2PS_OFF) | STE_W2_S2AA64 |
+        STE_W2_S2AFFD | STE_W2_S2R;
+
+    spin_lock(&smmu.lock);
+    struct smmuv3_ste* e = &smmu.st[sid];
+
+    /* Clear valid first so the SMMU never sees a half-written translate STE. */
+    e->data[0] = 0;
+    smmuv3_push((vaddr_t)e, sizeof(*e));
+    smmuv3_cmdq_cfgi_ste(sid);
+    smmuv3_cmdq_sync();
+
+    e->data[1] = 0;
+    e->data[2] = w2;
+    e->data[3] = root_pt & STE_W3_S2TTB_MASK;
+    e->data[4] = 0;
+    e->data[5] = 0;
+    e->data[6] = 0;
+    e->data[7] = 0;
+    smmuv3_push((vaddr_t)e, sizeof(*e));
+
+    e->data[0] = STE_W0_V | (STE_W0_CONFIG_S2 << STE_W0_CONFIG_OFF);
+    smmuv3_push((vaddr_t)e, sizeof(*e));
+
+    smmuv3_cmdq_cfgi_ste(sid);
+    smmuv3_cmdq_tlbi_vmid(vmid);
+    smmuv3_cmdq_sync();
+    spin_unlock(&smmu.lock);
+
+    /* NOTE: this TLBI at bind is the ONLY SMMU stage-2 invalidation. The driver
+     * assumes a bound VM's stage-2 mappings are static afterwards -- true under
+     * Bao's static-partitioning model. Nothing invalidates the SMMU when a VM
+     * stage-2 is mutated at runtime (see the // TODO: inval iommu tlbs sites in
+     * core/inc/tlb.h); adding dynamic remap MUST hook SMMU invalidation there or
+     * the SMMU will translate against stale walk-cache/TLB entries. */
+
+    INFO("smmuv3: stream %d -> stage-2 (vmid %d, s2ttb 0x%lx)", sid, vmid,
+        (unsigned long)(root_pt & STE_W3_S2TTB_MASK));
+    return true;
+}

--- a/src/arch/armv8/gic.c
+++ b/src/arch/armv8/gic.c
@@ -17,6 +17,9 @@
 #include <cpu.h>
 #include <spinlock.h>
 #include <platform.h>
+#if (SMMU_VERSION == 3)
+#include <arch/smmuv3.h>
+#endif
 #include <fences.h>
 
 volatile struct gicd_hw* gicd;
@@ -107,6 +110,16 @@ void gic_handle()
             gicc_dir(ack);
         }
     }
+
+#if (SMMU_VERSION == 3)
+    /* Surface any SMMU translation faults (a refused DMA usually coincides with
+     * a device error IRQ). Scoped to the master CPU: the wired eventq IRQ is the
+     * primary path, so this only needs to be a backstop, not a per-IRQ,
+     * per-core MMIO poll. */
+    if (cpu_is_master()) {
+        smmuv3_poll_events();
+    }
+#endif
 }
 
 uint8_t gicd_get_prio(irqid_t int_id)

--- a/src/arch/armv8/inc/arch/platform.h
+++ b/src/arch/armv8/inc/arch/platform.h
@@ -8,7 +8,7 @@
 
 #include <bao.h>
 #ifdef MEM_PROT_MMU
-#include <arch/smmuv2.h>
+#include <arch/smmu.h>
 #endif
 
 struct arch_platform {

--- a/src/arch/armv8/inc/arch/vm.h
+++ b/src/arch/armv8/inc/arch/vm.h
@@ -11,7 +11,7 @@
 #include <arch/vgic.h>
 #include <arch/psci.h>
 #ifdef MEM_PROT_MMU
-#include <arch/smmuv2.h>
+#include <arch/smmu.h>
 #endif
 #include <list.h>
 
@@ -27,6 +27,10 @@ struct arch_vm_platform {
     struct {
         streamid_t global_mask;
         size_t group_num;
+        /* A streamID is only unique within a single SMMU instance. The drivers
+         * currently assume one SMMU per SoC; multi-SMMU support would add a
+         * per-group instance selector here (e.g. an "smmu_idx" field) so each
+         * group can target a specific SMMU without breaking this interface. */
         struct smmu_group {
             streamid_t mask;
             streamid_t id;

--- a/src/core/inc/tlb.h
+++ b/src/core/inc/tlb.h
@@ -18,6 +18,15 @@ static inline void tlb_inv_va(struct addr_space* as, vaddr_t va)
     } else if (as->type == AS_VM) {
         tlb_vm_inv_va(as->id, va);
         // TODO: inval iommu tlbs
+        //
+        // The SMMU (see arch/armv8 smmuv3) caches stage-2 walks in its own
+        // TLB/walk-cache and is NOT reached by the CPU-side TLBI above. The
+        // current drivers rely on the assumption that a bound VM's stage-2
+        // mappings are static after bind, so this stays correct only while
+        // nothing remaps an already-bound VM. Anyone adding dynamic stage-2
+        // remapping MUST hook an IOMMU stage-2 invalidation here (by VMID, or
+        // by IPA once supported) or the SMMU will translate against stale
+        // tables.
     }
 }
 
@@ -28,6 +37,11 @@ static inline void tlb_inv_all(struct addr_space* as)
     } else if (as->type == AS_VM) {
         tlb_vm_inv_all(as->id);
         // TODO: inval iommu tlbs
+        //
+        // Same caveat as tlb_inv_va(): the SMMU's stage-2 TLB/walk-cache is not
+        // invalidated by the CPU-side TLBI above. Correct today only because a
+        // bound VM's stage-2 is static after bind; a dynamic remap MUST also
+        // invalidate the IOMMU (SMMU) here.
     }
 }
 


### PR DESCRIPTION
Add a minimal ARM SMMUv3 (IHI 0070) driver for Armv8-A, providing stage-2-only DMA translation. The driver takes over the non-secure SMMU left enabled by firmware: it installs a linear stream table (all streams BYPASS by default so masters keep working with their incoming attributes), a command queue and an event queue, and promotes individual streams to stage-2 as VMs bind them. Faults are drained and logged via the event queue (wired SPI plus a cheap poll hook on the GIC IRQ path).

Driver selection is done at build time via SMMU_VERSION (default 2): arch/smmu.h resolves to smmuv2.h or smmuv3.h, and objects.mk builds the matching driver. Platforms opt into v3 with SMMU_VERSION:=3 in their platform.mk.

Verified working on Agilex5 SoCFPGA platform. 