### PR TITLE
fix(ci): free runner disk space before image pull

### DIFF
--- a/.github/actions/bao-container-run/action.yml
+++ b/.github/actions/bao-container-run/action.yml
@@ -1,0 +1,26 @@
+name: Run in Bao CI container
+description: >
+  Frees runner disk space and runs a command inside the baoproject/bao
+  container. Stopgap while the CI image is too large for the free disk on
+  GitHub-hosted runners (see bao-project/bao-ci#94): with the `container:`
+  directive the image is pulled before any step can clean up, so jobs mount
+  the workspace and run the container explicitly instead.
+inputs:
+  run:
+    description: Command to run inside the container
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Free runner disk space
+      shell: bash
+      run: >
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+        /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+    - name: Run in container
+      shell: bash
+      run: >
+        docker run --rm -v "${{ github.workspace }}:/bao" -w /bao
+        baoproject/bao:latest
+        bash -c "git config --global --add safe.directory '*' &&
+        ${{ inputs.run }}"

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -10,27 +10,31 @@ jobs:
 
   gitlint:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - run: git config --global --add safe.directory $(realpath .)
       - if: ${{ github.event_name == 'pull_request' }}
-        run: make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
+        uses: ./.github/actions/bao-container-run
+        with:
+          run: make gitlint GITLINT_BASE=${{ github.event.pull_request.base.sha }}
       - if: ${{ github.event_name == 'push' }}
-        run: make gitlint GITLINT_BASE=${{ github.event.before }}
+        uses: ./.github/actions/bao-container-run
+        with:
+          run: make gitlint GITLINT_BASE=${{ github.event.before }}
       - if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: make gitlint GITLINT_BASE=HEAD
+        uses: ./.github/actions/bao-container-run
+        with:
+          run: make gitlint GITLINT_BASE=HEAD
 
   license:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - run: >
-          make license-check
+      - uses: ./.github/actions/bao-container-run
+        with:
+          run: make license-check

--- a/.github/workflows/build-arm.yaml
+++ b/.github/workflows/build-arm.yaml
@@ -10,7 +10,6 @@ jobs:
 
   build-arm:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     strategy:
       matrix:
         platform: [
@@ -31,5 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: make PLATFORM=${{ matrix.platform }} GIC_VERSION=${{ matrix.gic }} \
+      - uses: ./.github/actions/bao-container-run
+        with:
+          run: make PLATFORM=${{ matrix.platform }} GIC_VERSION=${{ matrix.gic }}
             CONFIG=null ${{ matrix.cross_compile }}

--- a/.github/workflows/build-riscv.yaml
+++ b/.github/workflows/build-riscv.yaml
@@ -10,7 +10,6 @@ jobs:
 
   build-riscv:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     strategy:
       matrix:
         platform: [
@@ -34,5 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: make PLATFORM=${{ matrix.platform }} IRQC=${{ matrix.irqc }} \
+      - uses: ./.github/actions/bao-container-run
+        with:
+          run: make PLATFORM=${{ matrix.platform }} IRQC=${{ matrix.irqc }}
             IPIC=${{ matrix.ipic }} CONFIG=null ${{ matrix.cross_compile }}

--- a/.github/workflows/build-tricore.yaml
+++ b/.github/workflows/build-tricore.yaml
@@ -10,7 +10,6 @@ jobs:
 
   build-tricore:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     strategy:
       matrix:
         platform: [
@@ -23,5 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: make PLATFORM=${{ matrix.platform }} \
+      - uses: ./.github/actions/bao-container-run
+        with:
+          run: make PLATFORM=${{ matrix.platform }}
             CONFIG=null ${{ matrix.cross_compile }}

--- a/.github/workflows/build-v850.yaml
+++ b/.github/workflows/build-v850.yaml
@@ -10,7 +10,6 @@ jobs:
 
   build-rh850:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     strategy:
       matrix:
         platform: [
@@ -20,4 +19,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: make PLATFORM=${{ matrix.platform }} CONFIG=null
+      - uses: ./.github/actions/bao-container-run
+        with:
+          run: make PLATFORM=${{ matrix.platform }} CONFIG=null

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,10 +10,11 @@ jobs:
   
   coding-style:
     runs-on: ubuntu-latest
-    container: baoproject/bao:latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
-      - run: make format-check
+      - uses: ./.github/actions/bao-container-run
+        with:
+          run: make format-check


### PR DESCRIPTION
## Problem

The `baoproject/bao` container image (5.5 GB compressed, ~9 GB extracted) no longer fits in the ~14 GB of free disk on GitHub-hosted runners, so jobs fail during image pull:

```
failed to register layer: write /opt/v850-toolchain/v850-elf/lib/soft-float/libstdc++exp.a: no space left on device
Error: Docker pull failed with exit code 1
```

With the `container:` job directive the image is pulled during job initialization, before any step runs, so no cleanup step can help while that directive is used.

## Change

Adds a composite action (`.github/actions/bao-container-run`) that:

1. Frees ~25 GB by removing preinstalled runner software the CI never uses (dotnet, Android SDK, GHC, CodeQL)
2. Runs the job's command inside `baoproject/bao:latest` via `docker run` with the workspace mounted

All jobs drop the `container:` directive and run their (unchanged) make invocations through this action. The `safe.directory` git config moved into the action since the checkout now happens on the host as a different user than the container's root; this covers the gitlint job's previous explicit step and the git usage of the other targets.

The disk cleanup adds roughly 1 to 2 minutes per job. If that proves annoying it can be overlapped with the image pull in a follow-up.

This is a stopgap until the image is split into per-architecture images with a common base layer, see bao-project/bao-ci#94.

## Testing

- actionlint clean on all modified workflows
- Local runs of the exact container command: `qemu-riscv64-virt` build, `license-check` and `gitlint` all pass inside `docker run` with a host-owned checkout
- The workflows in this PR run with these changes, so green checks here validate the fix on real runners

