### PR TITLE
fix(armv8): lock target psci_ctx in PSCI CPU_ON

### DIFF
--- a/src/arch/armv8/psci.c
+++ b/src/arch/armv8/psci.c
@@ -105,7 +105,7 @@ static int32_t psci_cpu_on_handler(unsigned long target_cpu, unsigned long entry
 
     if (target_vcpu != NULL) {
         bool already_on = true;
-        spin_lock(&cpu()->vcpu->arch.psci_ctx.lock);
+        spin_lock(&target_vcpu->arch.psci_ctx.lock);
         if (target_vcpu->arch.psci_ctx.state == OFF) {
             target_vcpu->arch.psci_ctx.state = ON_PENDING;
             target_vcpu->arch.psci_ctx.entrypoint = entrypoint;
@@ -113,7 +113,7 @@ static int32_t psci_cpu_on_handler(unsigned long target_cpu, unsigned long entry
             fence_sync_write();
             already_on = false;
         }
-        spin_unlock(&cpu()->vcpu->arch.psci_ctx.lock);
+        spin_unlock(&target_vcpu->arch.psci_ctx.lock);
 
         if (already_on) {
             return PSCI_E_ALREADY_ON;


### PR DESCRIPTION
psci_cpu_on_handler mutated target_vcpu->arch.psci_ctx while holding the caller psci_ctx.lock. Concurrent PSCI_CPU_ON on the same secondary was not serialized: both callers could observe OFF, return SUCCESS, and overwrite entrypoint/context_id.

Lock target_vcpu->arch.psci_ctx.lock instead, matching the RISC-V sbi_hsm_start_handler pattern.

Verified on QEMU virt (aarch64) with concurrent CPU_ON from two vCPUs against one OFF secondary: one SUCCESS and one ALREADY_ON. Sequential SMP bring-up still succeeds.

Issue: #386