### PR TITLE
fix: latent cache coherency issues in relocation and cache flush

### DIFF
--- a/src/arch/armv8/cache.c
+++ b/src/arch/armv8/cache.c
@@ -114,5 +114,6 @@ void cache_flush_range(vaddr_t base, size_t size)
         cache_addr += min_line_size;
     }
 
-    DMB(ish);
+    /* Ensure the cache maintenance operations complete before returning */
+    DSB(ish);
 }

--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -5,12 +5,12 @@ ARCH_SUB?=riscv64
 
 ifeq ($(ARCH_SUB), riscv64)
 CROSS_COMPILE ?= riscv64-unknown-elf-
-riscv_march:=rv64imac_zicsr_zicbom
+riscv_march:=rv64imac_zicsr_zicbom_zifencei
 riscv_mabi:=lp64
 ld_emulation:=elf64lriscv
 else ifeq ($(ARCH_SUB), riscv32)
 CROSS_COMPILE ?= riscv32-unknown-elf-
-riscv_march:=rv32imac_zicsr_zicbom
+riscv_march:=rv32imac_zicsr_zicbom_zifencei
 riscv_mabi:=ilp32
 ld_emulation:=elf32lriscv
 else

--- a/src/arch/riscv/relocate.S
+++ b/src/arch/riscv/relocate.S
@@ -53,6 +53,9 @@ switch_space:
     sub a6, a6, a4
     sub a0, a0, a4
 
+    /* Synchronize instruction fetch with the data-side copy of the relocated image */
+    fence.i
+
     /* Update root page table pointer */
     srl a1, a1, PAGE_SHIFT
     li  t0, SATP_MODE_DFLT


### PR DESCRIPTION
`cache_flush_range()` on armv8 ended with a `dmb`, which does not guarantee completion of the cache maintenance operations, while its callers rely on it: the relocation flow before other cores fetch the relocated image, the guest image flush, and the psci off state flush before a core powers down. Replace it with a `dsb`.

The riscv `switch_space()` never executed `fence.i`, so instruction fetch is not synchronized with the data-side copy of the relocated image, the same problem #391 fixes for aarch64. Execute it just before the `satp` write, while still fetching from the original pages. This requires enabling `zifencei` in the march string.

Both qemu-aarch64-virt and qemu-riscv64-virt builds pass.
