### PR TITLE
fix(armv8/vgic): correct addressing of forwarded register writes

### DIFF
--- a/src/arch/armv8/inc/arch/vgic.h
+++ b/src/arch/armv8/inc/arch/vgic.h
@@ -120,7 +120,7 @@ void vgic_send_sgi_msg(struct vcpu* vcpu, cpumap_t pcpu_mask, irqid_t int_id);
 size_t vgic_get_itln(const struct vgic_dscrp* vgic_dscrp);
 struct vgic_int* vgic_get_int(struct vcpu* vcpu, irqid_t int_id, vcpuid_t vgicr_id);
 void vgic_int_set_field(struct vgic_reg_handler_info* handlers, struct vcpu* vcpu,
-    struct vgic_int* interrupt, unsigned long data);
+    struct vgic_int* interrupt, unsigned long data, vcpuid_t vgicr_id);
 void vgic_emul_razwi(struct emul_access* acc, struct vgic_reg_handler_info* handlers,
     bool gicr_access, cpuid_t vgicr_id);
 

--- a/src/arch/armv8/inc/arch/vgic.h
+++ b/src/arch/armv8/inc/arch/vgic.h
@@ -121,6 +121,7 @@ size_t vgic_get_itln(const struct vgic_dscrp* vgic_dscrp);
 struct vgic_int* vgic_get_int(struct vcpu* vcpu, irqid_t int_id, vcpuid_t vgicr_id);
 void vgic_int_set_field(struct vgic_reg_handler_info* handlers, struct vcpu* vcpu,
     struct vgic_int* interrupt, unsigned long data, vcpuid_t vgicr_id);
+void vgic_int_reroute(struct vcpu* vcpu, struct vgic_int* interrupt);
 void vgic_emul_razwi(struct emul_access* acc, struct vgic_reg_handler_info* handlers,
     bool gicr_access, cpuid_t vgicr_id);
 

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -32,14 +32,16 @@ extern volatile const size_t VGIC_IPI_ID;
 #define GICD_REG_MASK(ADDR) ((ADDR) & (GIC_VERSION == GICV2 ? 0xfffUL : 0xffffUL))
 #define GICD_REG_IND(REG)   (offsetof(struct gicd_hw, REG) & 0x7f)
 
-#define VGIC_MSG_DATA(VM_ID, VGICRID, INT_ID, REG, VAL)                   \
-    (((uint64_t)(VM_ID) << 48) | (((uint64_t)(VGICRID) & 0xffff) << 32) | \
-        (((INT_ID) & 0x7fff) << 16) | (((REG) & 0xff) << 8) | ((VAL) & 0xff))
-#define VGIC_MSG_VM(DATA)      ((DATA) >> 48)
-#define VGIC_MSG_VGICRID(DATA) (((DATA) >> 32) & 0xffff)
-#define VGIC_MSG_INTID(DATA)   (((DATA) >> 16) & 0x7fff)
-#define VGIC_MSG_REG(DATA)     (((DATA) >> 8) & 0xff)
-#define VGIC_MSG_VAL(DATA)     ((DATA) & 0xff)
+union vgic_msg_data {
+    struct {
+        uint16_t vm_id;
+        uint16_t vgicr_id;
+        uint16_t int_id;
+        uint8_t reg;
+        uint8_t val;
+    };
+    uint64_t raw;
+};
 
 void vgic_ipi_handler(uint32_t event, uint64_t data);
 CPU_MSG_HANDLER(vgic_ipi_handler, VGIC_IPI_ID)
@@ -131,11 +133,12 @@ void vgic_send_sgi_msg(struct vcpu* vcpu, cpumap_t pcpu_mask, irqid_t int_id)
 {
     UNUSED_ARG(vcpu);
 
-    struct cpu_msg msg = {
-        (uint32_t)VGIC_IPI_ID,
-        VGIC_INJECT,
-        VGIC_MSG_DATA(cpu()->vcpu->vm->id, 0, int_id, 0, cpu()->vcpu->id),
+    union vgic_msg_data data = {
+        .vm_id = (uint16_t)cpu()->vcpu->vm->id,
+        .int_id = (uint16_t)int_id,
+        .val = (uint8_t)cpu()->vcpu->id,
     };
+    struct cpu_msg msg = { (uint32_t)VGIC_IPI_ID, VGIC_INJECT, data.raw };
 
     for (size_t i = 0; i < platform.cpu_num; i++) {
         if (pcpu_mask & (1ULL << i)) {
@@ -155,11 +158,12 @@ static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
     }
 
     if (!interrupt->in_lr && vgic_int_has_other_target(vcpu, interrupt)) {
-        struct cpu_msg msg = {
-            (uint32_t)VGIC_IPI_ID,
-            VGIC_ROUTE,
-            VGIC_MSG_DATA(vcpu->vm->id, vcpu->id, interrupt->id, 0, 0),
+        union vgic_msg_data data = {
+            .vm_id = (uint16_t)vcpu->vm->id,
+            .vgicr_id = (uint16_t)vcpu->id,
+            .int_id = (uint16_t)interrupt->id,
         };
+        struct cpu_msg msg = { (uint32_t)VGIC_IPI_ID, VGIC_ROUTE, data.raw };
         vgic_yield_ownership(vcpu, interrupt);
         cpumap_t trgtlist = vgic_int_ptarget_mask(vcpu, interrupt) & ~(1UL << vcpu->phys_id);
         for (size_t i = 0; i < platform.cpu_num; i++) {
@@ -410,11 +414,10 @@ static void vgicd_emul_misc_access(struct emul_access* acc, struct vgic_reg_hand
                 vgicd->CTLR = vcpu_readreg(cpu()->vcpu, acc->reg) & VGIC_ENABLE_MASK;
                 if (prev_ctrl ^ vgicd->CTLR) {
                     vgic_update_enable(cpu()->vcpu);
-                    struct cpu_msg msg = {
-                        (uint32_t)VGIC_IPI_ID,
-                        VGIC_UPDATE_ENABLE,
-                        VGIC_MSG_DATA(cpu()->vcpu->vm->id, 0, 0, 0, 0),
+                    union vgic_msg_data data = {
+                        .vm_id = (uint16_t)cpu()->vcpu->vm->id,
                     };
+                    struct cpu_msg msg = { (uint32_t)VGIC_IPI_ID, VGIC_UPDATE_ENABLE, data.raw };
                     vm_msg_broadcast(cpu()->vcpu->vm, &msg);
                 }
             } else {
@@ -694,11 +697,13 @@ void vgic_int_set_field(struct vgic_reg_handler_info* handlers, struct vcpu* vcp
         vgic_route(vcpu, interrupt);
         vgic_yield_ownership(vcpu, interrupt);
     } else {
-        struct cpu_msg msg = {
-            (uint32_t)VGIC_IPI_ID,
-            VGIC_SET_REG,
-            VGIC_MSG_DATA(vcpu->vm->id, 0, interrupt->id, handlers->regid, data),
+        union vgic_msg_data msg_data = {
+            .vm_id = (uint16_t)vcpu->vm->id,
+            .int_id = (uint16_t)interrupt->id,
+            .reg = (uint8_t)handlers->regid,
+            .val = (uint8_t)data,
         };
+        struct cpu_msg msg = { (uint32_t)VGIC_IPI_ID, VGIC_SET_REG, msg_data.raw };
         cpu_send_msg(interrupt->owner->phys_id, &msg);
     }
     spin_unlock(&interrupt->lock);
@@ -1003,10 +1008,11 @@ void vgic_inject(struct vcpu* vcpu, irqid_t id, vcpuid_t source)
 
 void vgic_ipi_handler(uint32_t event, uint64_t data)
 {
-    uint16_t vm_id = (uint16_t)VGIC_MSG_VM(data);
-    uint16_t vgicr_id = (uint16_t)VGIC_MSG_VGICRID(data);
-    irqid_t int_id = VGIC_MSG_INTID(data);
-    uint64_t val = VGIC_MSG_VAL(data);
+    union vgic_msg_data msg = { .raw = data };
+    uint16_t vm_id = msg.vm_id;
+    uint16_t vgicr_id = msg.vgicr_id;
+    irqid_t int_id = msg.int_id;
+    uint64_t val = msg.val;
 
     if (vm_id != cpu()->vcpu->vm->id) {
         ERROR("received vgic3 msg target to another vcpu\n");
@@ -1037,7 +1043,7 @@ void vgic_ipi_handler(uint32_t event, uint64_t data)
         } break;
 
         case VGIC_SET_REG: {
-            uint64_t reg_id = VGIC_MSG_REG(data);
+            uint64_t reg_id = msg.reg;
             struct vgic_reg_handler_info* handlers = vgic_get_reg_handler_info(reg_id);
             struct vgic_int* interrupt = vgic_get_int(cpu()->vcpu, int_id, vgicr_id);
             if (handlers != NULL && interrupt != NULL) {

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -710,6 +710,30 @@ void vgic_int_set_field(struct vgic_reg_handler_info* handlers, struct vcpu* vcp
     spin_unlock(&interrupt->lock);
 }
 
+/**
+ * Applies the side effects of a route change: pulls the interrupt out of the previous target's
+ * list registers and re-delivers it according to the current route. The route value itself is
+ * updated at the emulation site, so the message forwarded to a remote owner carries no data.
+ */
+void vgic_int_reroute(struct vcpu* vcpu, struct vgic_int* interrupt)
+{
+    spin_lock(&interrupt->lock);
+    if (vgic_get_ownership(vcpu, interrupt)) {
+        vgic_remove_lr(vcpu, interrupt);
+        vgic_route(vcpu, interrupt);
+        vgic_yield_ownership(vcpu, interrupt);
+    } else {
+        union vgic_msg_data msg_data = {
+            .vm_id = (uint16_t)vcpu->vm->id,
+            .int_id = (uint16_t)interrupt->id,
+            .reg = (uint8_t)VGIC_IROUTER_ID,
+        };
+        struct cpu_msg msg = { (uint32_t)VGIC_IPI_ID, VGIC_SET_REG, msg_data.raw };
+        cpu_send_msg(interrupt->owner->phys_id, &msg);
+    }
+    spin_unlock(&interrupt->lock);
+}
+
 void vgic_emul_generic_access(struct emul_access* acc, struct vgic_reg_handler_info* handlers,
     bool gicr_access, cpuid_t vgicr_id)
 {
@@ -1047,9 +1071,10 @@ void vgic_ipi_handler(uint32_t event, uint64_t data)
             uint64_t reg_id = msg.reg;
             struct vgic_reg_handler_info* handlers = vgic_get_reg_handler_info(reg_id);
             struct vgic_int* interrupt = vgic_get_int(cpu()->vcpu, int_id, vgicr_id);
-            if (handlers != NULL && interrupt != NULL) {
-                vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)val,
-                    vgicr_id);
+            if (interrupt != NULL && reg_id == VGIC_IROUTER_ID) {
+                vgic_int_reroute(cpu()->vcpu, interrupt);
+            } else if (handlers != NULL && interrupt != NULL) {
+                vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)val, vgicr_id);
             }
         } break;
 

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -686,7 +686,7 @@ void vgic_emul_razwi(struct emul_access* acc, struct vgic_reg_handler_info* hand
 }
 
 void vgic_int_set_field(struct vgic_reg_handler_info* handlers, struct vcpu* vcpu,
-    struct vgic_int* interrupt, unsigned long data)
+    struct vgic_int* interrupt, unsigned long data, vcpuid_t vgicr_id)
 {
     spin_lock(&interrupt->lock);
     if (vgic_get_ownership(vcpu, interrupt)) {
@@ -699,6 +699,7 @@ void vgic_int_set_field(struct vgic_reg_handler_info* handlers, struct vcpu* vcp
     } else {
         union vgic_msg_data msg_data = {
             .vm_id = (uint16_t)vcpu->vm->id,
+            .vgicr_id = (uint16_t)vgicr_id,
             .int_id = (uint16_t)interrupt->id,
             .reg = (uint8_t)handlers->regid,
             .val = (uint8_t)data,
@@ -727,7 +728,7 @@ void vgic_emul_generic_access(struct emul_access* acc, struct vgic_reg_handler_i
             }
             if (acc->write) {
                 unsigned long data = bit_extract(val, i * field_width, field_width);
-                vgic_int_set_field(handlers, cpu()->vcpu, interrupt, data);
+                vgic_int_set_field(handlers, cpu()->vcpu, interrupt, data, vgicr_id);
             } else {
                 val |= (handlers->read_field(cpu()->vcpu, interrupt) & mask) << (i * field_width);
             }
@@ -1001,7 +1002,7 @@ void vgic_inject(struct vcpu* vcpu, irqid_t id, vcpuid_t source)
         } else if (GIC_VERSION == GICV2 && gic_is_sgi(id)) {
             vgic_inject_sgi(vcpu, interrupt, source);
         } else {
-            vgic_int_set_field(&ispendr_info, vcpu, interrupt, true);
+            vgic_int_set_field(&ispendr_info, vcpu, interrupt, true, vcpu->id);
         }
     }
 }
@@ -1047,7 +1048,8 @@ void vgic_ipi_handler(uint32_t event, uint64_t data)
             struct vgic_reg_handler_info* handlers = vgic_get_reg_handler_info(reg_id);
             struct vgic_int* interrupt = vgic_get_int(cpu()->vcpu, int_id, vgicr_id);
             if (handlers != NULL && interrupt != NULL) {
-                vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)val);
+                vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)val,
+                    vgicr_id);
             }
         } break;
 

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -121,8 +121,8 @@ static bool vgic_owns(struct vcpu* vcpu, struct vgic_int* interrupt)
 
 void vgic_yield_ownership(struct vcpu* vcpu, struct vgic_int* interrupt)
 {
-    if ((GIC_VERSION == GICV2 && gic_is_priv(interrupt->id)) || !vgic_owns(vcpu, interrupt) ||
-        interrupt->in_lr || (vgic_get_state(interrupt) & ACT)) {
+    if (gic_is_priv(interrupt->id) || !vgic_owns(vcpu, interrupt) || interrupt->in_lr ||
+        (vgic_get_state(interrupt) & ACT)) {
         return;
     }
 

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -401,7 +401,7 @@ void vgic_init(struct vm* vm, const struct vgic_dscrp* vgic_dscrp)
 void vgic_cpu_init(struct vcpu* vcpu)
 {
     for (irqid_t i = 0; i < GIC_CPU_PRIV; i++) {
-        vcpu->arch.vgic_priv.interrupts[i].owner = NULL;
+        vcpu->arch.vgic_priv.interrupts[i].owner = vcpu;
         vcpu->arch.vgic_priv.interrupts[i].lock = SPINLOCK_INITVAL;
         vcpu->arch.vgic_priv.interrupts[i].id = i;
         vcpu->arch.vgic_priv.interrupts[i].state = INV;

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -166,7 +166,7 @@ static void vgicd_emul_router_access(struct emul_access* acc,
         } else {
             route = reg_value;
         }
-        vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)route);
+        vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)route, vgicr_id);
     }
 }
 

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -159,6 +159,14 @@ static void vgicd_emul_router_access(struct emul_access* acc,
         }
     } else {
         uint64_t reg_value = vcpu_readreg(cpu()->vcpu, acc->reg);
+
+        /**
+         * The route is updated here, under the interrupt lock, so partial word writes always
+         * merge against the current value. Only the routing side effects are deferred to the
+         * interrupt owner through vgic_int_reroute.
+         */
+        spin_lock(&interrupt->lock);
+        route = vgic_int_get_route(cpu()->vcpu, interrupt);
         if (top_access) {
             route = (route & BIT64_MASK(0, 32)) | ((reg_value & BIT64_MASK(0, 32)) << 32);
         } else if (word_access) {
@@ -166,7 +174,13 @@ static void vgicd_emul_router_access(struct emul_access* acc,
         } else {
             route = reg_value;
         }
-        vgic_int_set_field(handlers, cpu()->vcpu, interrupt, (unsigned long)route, vgicr_id);
+        /* spis only past this point, so hw status does not depend on the sgi check */
+        if (vgic_int_set_route(cpu()->vcpu, interrupt, (unsigned long)route) && interrupt->hw) {
+            vgic_int_set_route_hw(cpu()->vcpu, interrupt);
+        }
+        spin_unlock(&interrupt->lock);
+
+        vgic_int_reroute(cpu()->vcpu, interrupt);
     }
 }
 

--- a/src/arch/armv8/vgicv3.c
+++ b/src/arch/armv8/vgicv3.c
@@ -155,7 +155,7 @@ static void vgicd_emul_router_access(struct emul_access* acc,
         } else if (word_access) {
             vcpu_writereg(cpu()->vcpu, acc->reg, (uint32_t)route);
         } else {
-            vcpu_writereg(cpu()->vcpu, acc->reg, (uint32_t)route);
+            vcpu_writereg(cpu()->vcpu, acc->reg, (unsigned long)route);
         }
     } else {
         uint64_t reg_value = vcpu_readreg(cpu()->vcpu, acc->reg);


### PR DESCRIPTION
Four bugs in the vgic register emulation, plus a preparatory refactor of the message encoding.

- ref(armv8/vgic): pack vgic ipi messages in a bitfield union. Replaces the VGIC_MSG_* shift/mask macros with a union type. No functional change.
- fix(armv8/vgic): carry the redistributor id in forwarded register writes. The message hardcoded vgicr id 0, so a write to a private interrupt register of another vcpu's redistributor was applied to vcpu 0's interrupt instead of the intended one.
- fix(armv8/vgic): update the route at the emulation site. The router emulation merged partial word writes against a route value that could be behind an in-flight forward to a remote interrupt owner, so the second half of a split 64-bit guest write (all aarch32 guests write IROUTER in two 32-bit halves) could resurrect the old route and the update was silently lost. It also truncated the forwarded value to the 8-bit message val field, losing the IRM bit and any affinity above Aff0. The route and the physical routing are now updated at the access site under the interrupt lock, where merges always see the current value, and the message to the owner becomes a data-less request to re-evaluate the routing.
- fix(armv8/vgic): return the full 64-bit route on irouter reads. A doubleword read of IROUTER returned only the low word, truncating Aff3.
- fix(armv8/vgic): pin private interrupt ownership to its vcpu. On GICv3 private interrupts were initialized without an owner and the owner could later be yielded back to none, so a core emulating a write to another vcpu's redistributor could take ownership and handle the access in place, manipulating another vcpu's banked interrupt state from the wrong core. The owner is now set at init and never yielded, as already on GICv2, so remote redistributor writes are always forwarded to the owning core, where the vgicr id fix above makes them land on the right interrupt.

The forwarding fixes trigger whenever the written interrupt is owned by a vcpu on another cpu, which with the ownership pinning now includes every write to another vcpu's private interrupt registers. Build-tested for GICv3 and GICv2 on qemu-aarch64-virt, and GICv3 on mps3-an536 (aarch32). The route update path is exercised at runtime by a guest test that cycles an SPI's route across all cpus and verifies each delivery lands on the routed cpu.
