### PR TITLE
fix(armv8): avoid lost wake-up waiting for the boot barrier

### DIFF
--- a/src/arch/armv8/armv8-a/aarch32/boot.S
+++ b/src/arch/armv8/armv8-a/aarch32/boot.S
@@ -77,15 +77,17 @@ _barrier: .4byte 0
 	get_phys_addr r5, r4, _barrier
     mov r4, #1
     str r4, [r5]
-    sev 
+    dsb
+    sev
     b map_cpu
 
 wait_for_bsp:
     get_phys_addr r5, r4, _barrier
     ldr r4, [r5]
     cmp r4, #1
+    bge map_cpu
     wfe
-    blt wait_for_bsp
+    b wait_for_bsp
 
 map_cpu:
 

--- a/src/arch/armv8/armv8-a/aarch64/boot.S
+++ b/src/arch/armv8/armv8-a/aarch64/boot.S
@@ -92,16 +92,17 @@ boot_arch_profile_init:
 	adr x5, _boot_barrier
 	mov x4, #1
 	str x4, [x5]
-	//	dsb // arguments?
+	dsb ish
 	sev
 	b 	map_cpu
 
 wait_for_bsp:
 /* wait fot the bsp to finish up global mappings */
-	wfe
 	ldr x4, _boot_barrier
 	cmp x4, #1
-	b.lt wait_for_bsp
+	b.ge map_cpu
+	wfe
+	b wait_for_bsp
 
 map_cpu:
 	/**


### PR DESCRIPTION
Secondary cores wait on the phase-1 boot barrier with wfe before ever reading the flag (the aarch32 variant reads it, but sleeps once unconditionally before acting on the result). The bsp sets the flag and issues sev right after building the global boot page tables, long before the secondaries are powered on through PSCI. A core that comes up after the sev with its event register clear sleeps forever on a flag that is already set, and the bsp then hangs waiting for it at the cpu synchronization barrier.

Nothing guarantees that wake-up: the architecture leaves the event register in an UNKNOWN state out of reset. The code only ever worked because implementations either treated wfe as a nop or delivered stray events. QEMU made this concrete: up to v11.0 the A-profile wfe never slept in TCG, and since commit 01b223f895 ("target/arm: enable WFE sleeping for A-profile", in v11.1.0) it sleeps architecturally, which turns the race into a deterministic boot hang on qemu-aarch64-virt (all secondaries parked in wfe at wait_for_bsp, bsp spinning in cpu_sync_barrier). Confirmed by reading the barrier flag from a halted secondary while it slept.

Fix with the canonical sequence: check the flag first and only wfe while the check fails, and order the bsp's flag store before sev with a dsb (also resolving the commented-out "dsb?" doubt at that site). The phase-2 barrier already follows this discipline (stlr/ldar spin) and armv8-r has no boot barrier, so both are unaffected.

Verified at runtime on qemu-aarch64-virt with qemu v11.1.0, where the hang was 100% reproducible: with the fix bao boots through secondary bring-up to a 4-core guest. The aarch32 variant of the fix is build-tested.