### PR TITLE
feat(build): Kconfig-based build configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ targets:=all
 endif
 non_build_targets+=ci clean
 build_targets:=$(strip $(foreach target, $(targets), \
-	$(if $(findstring $(target),$(non_build_targets)),,$(target))))
+	$(if $(filter $(target),$(non_build_targets)),,$(target))))
 
 # Check platform target and set platform, driver and arch dirs based on it
 ifeq ($(PLATFORM),)

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,16 @@ endif
 ifneq ($(build_targets),)
 -include $(kconfig_auto_conf)
 
+# Platform facts are resolved by the platform choice in Kconfig; the
+# makefiles below only consume them
+ARCH:=$(CONFIG_ARCH)
+ARCH_SUB:=$(CONFIG_ARCH_SUB)
+ARCH_PROFILE:=$(CONFIG_ARCH_PROFILE)
+CPU:=$(CONFIG_CPU)
+GIC_VERSION:=$(CONFIG_GIC_VERSION)
+IRQC:=$(CONFIG_IRQC)
+IPIC:=$(CONFIG_IPIC)
+
 # Warn when a seed defconfig changed after this build was configured;
 # the working copy is authoritative and is never silently reseeded
 ifneq ($(wildcard $(kconfig_file)),)
@@ -193,7 +203,7 @@ $(foreach d, $(seed_defconfigs), \
 endif
 endif
 
--include $(platform_dir)/platform.mk	# must define ARCH and CPU variables
+-include $(platform_dir)/platform.mk	# platform build mechanics
 cpu_arch_dir=$(src_dir)/arch/$(ARCH)
 -include $(cpu_arch_dir)/arch.mk
 ifneq ($(arch_mem_prot),)

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ CPU:=$(CONFIG_CPU)
 GIC_VERSION:=$(CONFIG_GIC_VERSION)
 IRQC:=$(CONFIG_IRQC)
 IPIC:=$(CONFIG_IPIC)
+arch_mem_prot:=$(if $(filter y,$(CONFIG_MEM_PROT_MPU)),mpu,mmu)
 
 # Warn when a seed defconfig changed after this build was configured;
 # the working copy is authoritative and is never silently reseeded
@@ -296,29 +297,11 @@ objs-y:=$(abspath $(sort $(objs-y)))
 
 # Toolchain flags
 
-build_macros:=
-ifeq ($(arch_mem_prot),mmu)
-	build_macros+=-DMEM_PROT_MMU
-endif
-ifeq ($(arch_mem_prot),mpu)
-	build_macros+=-DMEM_PROT_MPU
-endif
-ifeq ($(plat_mem),non_unified)
-	ifeq ($(ARCH),aarch64)
-		$(error AArch64 with non_unified memory is not supported)
-	endif
-	build_macros+=-DMEM_NON_UNIFIED
-endif
-ifeq ($(phys_irqs_only),y)
-	build_macros+=-DPHYS_IRQS_ONLY
-endif
-ifeq ($(mmio_slave_side_prot),y)
-	build_macros+=-DMMIO_SLAVE_SIDE_PROT
-
-	ifneq ($(arch_mem_prot),mpu)
-		$(error mmio_slave_side_prot=y requires arch_mem_prot=mpu)
-	endif
-endif
+# Bridge kconfig-owned symbols to the unprefixed macro names the code uses
+kconfig_macros:=MEM_PROT_MMU MEM_PROT_MPU MEM_NON_UNIFIED PHYS_IRQS_ONLY \
+	MMIO_SLAVE_SIDE_PROT
+build_macros:=$(strip $(foreach m, $(kconfig_macros), \
+	$(if $(filter y, $(CONFIG_$(m))), -D$(m))))
 
 ifeq ($(CC_IS_GCC),y)
 	build_macros+=-DCC_IS_GCC

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,18 @@ targets:=$(MAKECMDGOALS)
 ifeq ($(targets),)
 targets:=all
 endif
-non_build_targets+=ci clean
+# Targets that are not build targets but still operate on a specific
+# platform/configuration pair
+config_targets:=menuconfig listconfig
+non_build_targets+=ci clean distclean $(config_targets)
 build_targets:=$(strip $(foreach target, $(targets), \
 	$(if $(filter $(target),$(non_build_targets)),,$(target))))
+plat_cfg_targets:=$(strip $(build_targets) \
+	$(filter $(config_targets), $(targets)))
 
 # Check platform target and set platform, driver and arch dirs based on it
 ifeq ($(PLATFORM),)
-ifneq ($(build_targets),)
+ifneq ($(plat_cfg_targets),)
  $(error Target platform argument (PLATFORM) not specified)
 endif
 endif
@@ -94,13 +99,6 @@ drivers_dir=$(platforms_dir)/drivers
 
 ifeq ($(wildcard $(platform_dir)),)
  $(error Target platform $(PLATFORM) is not supported)
-endif
-
--include $(platform_dir)/platform.mk	# must define ARCH and CPU variables
-cpu_arch_dir=$(src_dir)/arch/$(ARCH)
--include $(cpu_arch_dir)/arch.mk
-ifneq ($(MAKECMDGOALS), clean)
- core_mem_prot_dir:=$(core_dir)/$(arch_mem_prot)
 endif
 
 # Check configuration exists and set configurtion sources based on it
@@ -116,7 +114,7 @@ ifeq ($(config_src),)
   endif
 endif
 
-ifneq ($(build_targets),)
+ifneq ($(plat_cfg_targets),)
 ifeq ($(CONFIG),)
 $(error Configuration (CONFIG) not defined.)
 endif
@@ -128,7 +126,79 @@ endif
 
 build_dir:=$(cur_dir)/build/$(PLATFORM)/$(CONFIG)
 bin_dir:=$(cur_dir)/bin/$(PLATFORM)/$(CONFIG)
-directories:=$(build_dir) $(bin_dir)
+config_build_dir:=$(build_dir)/config
+platform_build_dir:=$(build_dir)/platform
+scripts_build_dir:=$(build_dir)/scripts
+directories:=$(build_dir) $(bin_dir) $(config_build_dir) \
+	$(config_build_dir)/inc $(platform_build_dir) $(scripts_build_dir)
+
+# Defconfig infrastructure: each build instance carries its own .config,
+# seeded from the defconfig lookup below, and synced by scripts/kconfig.py
+# into a make fragment (auto.conf) and a C header (autoconf.h) force-included
+# in every compilation unit
+kconfig_file:=$(build_dir)/.config
+kconfig_auto_conf:=$(config_build_dir)/auto.conf
+kconfig_auto_hdr:=$(config_build_dir)/autoconf.h
+kconfig_srcs:=$(shell find $(src_dir) -name Kconfig)
+kconfig_tool:=$(scripts_dir)/kconfig.py
+kconfig_env:=srctree=$(cur_dir) KCONFIG_ROOT=$(src_dir)/Kconfig \
+	KCONFIG_CONFIG=$(kconfig_file) BAO_PLATFORM=$(PLATFORM)
+# Seeding layers, applied in order: the platform's base defconfig, then the
+# VM config folder's defconfig (folder configurations only) overriding it,
+# then pure Kconfig defaults for whatever neither mentions
+seed_plat_defconfig:=$(wildcard $(platform_dir)/defconfig)
+seed_config_defconfig:=$(strip $(if $(filter-out $(CONFIG_REPO),$(config_dir)), \
+	$(wildcard $(config_dir)/defconfig)))
+seed_defconfigs:=$(seed_plat_defconfig) $(seed_config_defconfig)
+seed_defconfig_args:=\
+	$(if $(seed_plat_defconfig),--platform-defconfig $(seed_plat_defconfig)) \
+	$(if $(seed_config_defconfig),--config-defconfig $(seed_config_defconfig))
+
+$(kconfig_file):
+	@echo "Seeding config		$(patsubst $(cur_dir)/%,%, $@)"
+	@mkdir -p $(dir $@)
+	@$(kconfig_env) python3 $(kconfig_tool) seed $(seed_defconfig_args)
+
+$(kconfig_auto_conf): $(kconfig_file) $(kconfig_srcs) $(kconfig_tool)
+	@echo "Generating config	$(patsubst $(cur_dir)/%,%, $@)"
+	@mkdir -p $(config_build_dir)
+	@$(kconfig_env) python3 $(kconfig_tool) sync --auto-conf $@ \
+		--auto-header $(kconfig_auto_hdr)
+
+# The sync recipe above writes both files; a two-target rule would run it
+# once per target (racing under -j) and grouped targets (&:) need make 4.3+,
+# so the header instead tracks auto.conf through a recipe-less rule
+$(kconfig_auto_hdr): $(kconfig_auto_conf)
+
+# Configuration options are owned by Kconfig, which resolves their
+# dependencies; setting them out-of-band would bypass that resolution
+config_cli_overrides:=$(strip $(foreach v, \
+	$(filter-out CONFIG_REPO, $(filter CONFIG_%, $(.VARIABLES))), \
+	$(if $(filter command% override, $(origin $(v))), $(v))))
+ifneq ($(config_cli_overrides),)
+$(error Configuration options cannot be set on the command line \
+	($(config_cli_overrides)); change them via menuconfig or the defconfig)
+endif
+
+ifneq ($(build_targets),)
+-include $(kconfig_auto_conf)
+
+# Warn when a seed defconfig changed after this build was configured;
+# the working copy is authoritative and is never silently reseeded
+ifneq ($(wildcard $(kconfig_file)),)
+$(foreach d, $(seed_defconfigs), \
+	$(if $(shell test $(d) -nt $(kconfig_file) && echo y), \
+		$(warning $(d) is newer than this build's .config; remove \
+			$(kconfig_file) to adopt it)))
+endif
+endif
+
+-include $(platform_dir)/platform.mk	# must define ARCH and CPU variables
+cpu_arch_dir=$(src_dir)/arch/$(ARCH)
+-include $(cpu_arch_dir)/arch.mk
+ifneq ($(arch_mem_prot),)
+ core_mem_prot_dir:=$(core_dir)/$(arch_mem_prot)
+endif
 
 src_dirs+=$(cpu_arch_dir) $(lib_dir) $(core_dir) $(core_mem_prot_dir) \
 	$(platform_dir) $(addprefix $(drivers_dir)/, $(drivers)) $(config_dir)
@@ -155,12 +225,8 @@ inc_dirs+=$(patsubst $(cur_dir)%, $(build_dir)%, $(cpu_arch_dir))/inc
 deps+=$(asm_defs_hdr).d
 
 gens:=
+gens+=$(kconfig_auto_hdr)
 gens+=$(asm_defs_hdr)
-
-config_build_dir:=$(build_dir)/config
-platform_build_dir:=$(build_dir)/platform
-scripts_build_dir:=$(build_dir)/scripts
-directories+=$(config_build_dir) $(config_build_dir)/inc $(platform_build_dir) $(scripts_build_dir)
 
 config_def_generator_src:=$(scripts_dir)/config_defs_gen.c
 config_def_generator:=$(scripts_build_dir)/config_defs_gen
@@ -251,11 +317,12 @@ else ifeq ($(CC_IS_CLANG),y)
 endif
 
 override CPPFLAGS+=$(addprefix -I, $(inc_dirs)) $(arch-cppflags) \
-	$(platform-cppflags) $(build_macros) -DBAO_VERSION=\"$(version_str)\"
+	$(platform-cppflags) $(build_macros) -include $(kconfig_auto_hdr) \
+	-DBAO_VERSION=\"$(version_str)\"
 vpath:.=CPPFLAGS
 
 HOST_CPPFLAGS+=$(addprefix -I, $(inc_dirs)) $(arch-cppflags) \
-	$(platform-cppflags) $(build_macros)
+	$(platform-cppflags) $(build_macros) -include $(kconfig_auto_hdr)
 
 ifeq ($(DEBUG), y)
 	debug_flags:=-g
@@ -366,6 +433,10 @@ $(objs-y):
 	@echo "Generating binary	$(patsubst $(cur_dir)/%,%, $@)"
 	@$(objcopy) -S -O binary $< $@
 
+# Every generator compiles with the force-included kconfig header, so none
+# may run before it exists
+$(filter-out $(kconfig_auto_hdr), $(gens)) $(ld_script_temp): $(kconfig_auto_hdr)
+
 $(deps): | $(gens)
 
 #Generate assembly macro definitions from arch/$(ARCH)/$(asm_defs_src) if such
@@ -423,6 +494,16 @@ $(directories):
 
 endif
 
+# Configuration frontends operating on this build's .config
+
+.PHONY: menuconfig
+menuconfig: $(kconfig_file)
+	@$(kconfig_env) python3 $(kconfig_tool) menuconfig
+
+.PHONY: listconfig
+listconfig: $(kconfig_file)
+	@$(kconfig_env) python3 $(kconfig_tool) list $(seed_defconfig_args)
+
 # Count lines of code for the exact target platform and configuration
 
 .PHONY: cloc
@@ -431,11 +512,28 @@ cloc: | $(deps)
 
 #Clean all object, dependency and generated files
 
+# clean keeps the build's .config (a dotfile, unmatched by the wildcard);
+# distclean erases the configuration as well
+
 .PHONY: clean
 clean:
 	@echo "Erasing directories..."
+ifeq ($(PLATFORM),)
+	-rm -rf $(cur_dir)/build $(cur_dir)/bin
+else
+	-rm -rf $(wildcard $(build_dir)/*)
+	-rm -rf $(bin_dir)
+endif
+
+.PHONY: distclean
+distclean:
+	@echo "Erasing directories and configuration..."
+ifeq ($(PLATFORM),)
+	-rm -rf $(cur_dir)/build $(cur_dir)/bin
+else
 	-rm -rf $(build_dir)
 	-rm -rf $(bin_dir)
+endif
 
 # Instantiate CI rules
 

--- a/scripts/kconfig.py
+++ b/scripts/kconfig.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) Bao Project and Contributors. All rights reserved.
+
+"""Bao Kconfig helper.
+
+seed: create the build's .config (KCONFIG_CONFIG) by layering the platform
+      defconfig, then the VM config folder defconfig on top, then Kconfig
+      defaults for the rest, always pinning the platform given in
+      BAO_PLATFORM.
+sync: re-resolve .config against the Kconfig tree and generate the make
+      fragment (auto.conf) and C header (autoconf.h) consumed by the build.
+list: print every visible option with its value and which layer decided it
+      (default/platform/config/modified), plus the fixed platform facts.
+menuconfig: run the interactive frontend on the build's .config.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+import kconfiglib
+
+
+def platform_symbol(kconf, platform):
+    name = 'PLAT_' + platform.upper().replace('-', '_')
+    sym = kconf.syms.get(name)
+    if sym is None:
+        sys.exit(f'kconfig: platform {platform} has no {name} symbol')
+    return sym
+
+
+def check_platform(kconf, platform):
+    configured = kconf.syms['PLATFORM'].str_value
+    if configured != platform:
+        sys.exit(f'kconfig: .config is for platform {configured} but the '
+                 f'build targets {platform}; remove the build directory to '
+                 'reconfigure')
+
+
+def emitted_syms(kconf):
+    # Artifacts expose facts and values, not choice selector symbols; the
+    # platform identity symbol is the exception as code gates on it
+    for sym in kconf.unique_defined_syms:
+        if sym.choice and not sym.name.startswith('PLAT_'):
+            continue
+        yield sym
+
+
+def write_auto_conf(kconf, path):
+    with open(path, 'w') as f:
+        for sym in emitted_syms(kconf):
+            if sym.orig_type in (kconfiglib.BOOL, kconfiglib.TRISTATE):
+                if sym.tri_value > 0:
+                    f.write(f'CONFIG_{sym.name}=y\n')
+            elif sym.str_value:
+                f.write(f'CONFIG_{sym.name}={sym.str_value}\n')
+
+
+def write_auto_conf_header(kconf, path):
+    with open(path, 'w') as f:
+        for sym in emitted_syms(kconf):
+            if sym.orig_type in (kconfiglib.BOOL, kconfiglib.TRISTATE):
+                if sym.tri_value > 0:
+                    f.write(f'#define CONFIG_{sym.name} 1\n')
+            elif sym.orig_type is kconfiglib.STRING:
+                if sym.str_value:
+                    f.write(f'#define CONFIG_{sym.name} "{sym.str_value}"\n')
+            elif sym.str_value:
+                f.write(f'#define CONFIG_{sym.name} {sym.str_value}\n')
+
+
+def check_warnings(kconf):
+    if kconf.warnings:
+        for warning in kconf.warnings:
+            print(warning, file=sys.stderr)
+        sys.exit('kconfig: invalid configuration input')
+    for sym in kconf.unique_defined_syms:
+        if sym.user_value is None or sym.visibility:
+            continue
+        if sym.orig_type in (kconfiglib.BOOL, kconfiglib.TRISTATE):
+            mismatch = sym.user_value != sym.tri_value
+        else:
+            mismatch = sym.user_value != sym.str_value
+        if mismatch:
+            sys.exit(f'kconfig: CONFIG_{sym.name} is fixed by the platform '
+                     'selection and cannot be set in a defconfig')
+
+
+def defconfig_keys(path):
+    keys = set()
+    for line in open(path):
+        m = re.match(r'# CONFIG_([A-Za-z0-9_]+) is not set$|'
+                     r'CONFIG_([A-Za-z0-9_]+)=', line)
+        if m:
+            keys.add(m.group(1) or m.group(2))
+    return keys
+
+
+def load_defconfigs(kconf, paths):
+    # A later layer overriding an earlier one is the point of layering,
+    # not a suspect double assignment
+    kconf.warn_assign_override = False
+    kconf.warn_assign_redun = False
+    for i, path in enumerate(paths):
+        kconf.load_config(path, replace=(i == 0))
+
+
+def list_options(kconf, platform, plat_file, cfg_file):
+    plat_keys = defconfig_keys(plat_file) if plat_file else set()
+    cfg_keys = defconfig_keys(cfg_file) if cfg_file else set()
+    load_defconfigs(kconf, [f for f in (plat_file, cfg_file) if f])
+    platform_symbol(kconf, platform).set_value(2)
+    expected = {sym.name: sym.str_value for sym in kconf.unique_defined_syms}
+    if os.path.exists(os.environ.get('KCONFIG_CONFIG', '.config')):
+        kconf.load_config()
+    for sym in kconf.unique_defined_syms:
+        node = sym.nodes[0]
+        if sym.choice or not node.prompt or not sym.visibility:
+            continue
+        if sym.str_value != expected.get(sym.name):
+            source = 'modified'
+        elif sym.name in cfg_keys:
+            source = 'config'
+        elif sym.name in plat_keys:
+            source = 'platform'
+        else:
+            source = 'default'
+        default = (kconfiglib.expr_str(sym.defaults[0][0]) if sym.defaults
+                   else '-')
+        help_text = (node.help or '').strip().split('\n')[0]
+        print(f'CONFIG_{sym.name:<21} {kconfiglib.TYPE_TO_STR[sym.orig_type]:<5} '
+              f'{sym.str_value:<8} (default {default}) [{source}] {help_text}')
+    for sym in kconf.unique_defined_syms:
+        if sym.orig_type is kconfiglib.STRING and sym.str_value and \
+                not any(node.prompt for node in sym.nodes):
+            print(f'CONFIG_{sym.name:<21} fixed {sym.str_value}')
+
+
+def run_menuconfig():
+    import menuconfig
+
+    node_str = menuconfig._node_str
+
+    def blank_aware_node_str(node):
+        # Empty comments separate option and fact blocks in the menu view
+        if node.item is kconfiglib.COMMENT and not node.prompt[0]:
+            return ''
+        # @SYM@ placeholders in comments display the resolved symbol value
+        return re.sub(r'@([A-Z0-9_]+)@',
+                      lambda m: menuconfig._kconf.syms[m.group(1)].str_value,
+                      node_str(node))
+
+    menuconfig._node_str = blank_aware_node_str
+    sys.argv = [sys.argv[0], os.environ.get('KCONFIG_ROOT', 'Kconfig')]
+    menuconfig._main()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('command', choices=['seed', 'sync', 'list', 'menuconfig'])
+    parser.add_argument('--platform-defconfig')
+    parser.add_argument('--config-defconfig')
+    parser.add_argument('--auto-conf')
+    parser.add_argument('--auto-header')
+    args = parser.parse_args()
+
+    platform = os.environ.get('BAO_PLATFORM')
+    if not platform:
+        sys.exit('kconfig: BAO_PLATFORM not set')
+
+    if args.command == 'menuconfig':
+        run_menuconfig()
+        return
+
+    kconf = kconfiglib.Kconfig(os.environ.get('KCONFIG_ROOT', 'Kconfig'),
+                               suppress_traceback=True)
+
+    defconfigs = [f for f in (args.platform_defconfig,
+                              args.config_defconfig) if f]
+    if args.command == 'seed':
+        load_defconfigs(kconf, defconfigs)
+        platform_symbol(kconf, platform).set_value(2)
+        check_warnings(kconf)
+        check_platform(kconf, platform)
+        kconf.write_config()
+    elif args.command == 'sync':
+        kconf.load_config()
+        check_warnings(kconf)
+        check_platform(kconf, platform)
+        kconf.write_config()
+        write_auto_conf_header(kconf, args.auto_header)
+        write_auto_conf(kconf, args.auto_conf)
+    else:
+        list_options(kconf, platform, args.platform_defconfig,
+                     args.config_defconfig)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -5,3 +5,4 @@ mainmenu "Bao Hypervisor Configuration"
 
 source "src/arch/Kconfig"
 source "src/platform/Kconfig"
+source "src/core/Kconfig"

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -3,4 +3,5 @@
 
 mainmenu "Bao Hypervisor Configuration"
 
+source "src/arch/Kconfig"
 source "src/platform/Kconfig"

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -1,0 +1,6 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+mainmenu "Bao Hypervisor Configuration"
+
+source "src/platform/Kconfig"

--- a/src/arch/Kconfig
+++ b/src/arch/Kconfig
@@ -12,6 +12,16 @@ config ARCH_SUB
 config ARCH_PROFILE
 	string
 
+config MEM_PROT_MPU
+	bool
+
+config MEM_PROT_MMU
+	bool
+	default y if !MEM_PROT_MPU
+
+config PHYS_IRQS_ONLY
+	bool
+
 source "src/arch/armv8/Kconfig"
 source "src/arch/riscv/Kconfig"
 source "src/arch/rh850/Kconfig"

--- a/src/arch/Kconfig
+++ b/src/arch/Kconfig
@@ -1,0 +1,18 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+# Each architecture declares its own facts and options in its Kconfig file;
+# only the shared ARCH symbol is declared here
+config ARCH
+	string
+
+config ARCH_SUB
+	string
+
+config ARCH_PROFILE
+	string
+
+source "src/arch/armv8/Kconfig"
+source "src/arch/riscv/Kconfig"
+source "src/arch/rh850/Kconfig"
+source "src/arch/tricore/Kconfig"

--- a/src/arch/armv8/Kconfig
+++ b/src/arch/armv8/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config ARCH_ARMV8
+	bool
+
+config ARCH
+	default "armv8" if ARCH_ARMV8
+
+config CPU
+	string
+
+config GIC_VERSION
+	string

--- a/src/arch/armv8/Kconfig
+++ b/src/arch/armv8/Kconfig
@@ -12,3 +12,6 @@ config CPU
 
 config GIC_VERSION
 	string
+
+config MEM_PROT_MPU
+	default y if ARCH_ARMV8 && ARCH_PROFILE = "armv8-r"

--- a/src/arch/armv8/arch.mk
+++ b/src/arch/armv8/arch.mk
@@ -1,12 +1,10 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-ARCH_SUB?=aarch64
 arch_sub_dir:=$(cpu_arch_dir)/$(ARCH_SUB)
 include $(arch_sub_dir)/arch_sub.mk
 src_dirs+=$(arch_sub_dir)
 
-ARCH_PROFILE?=armv8-a
 arch_profile_dir:=$(cpu_arch_dir)/$(ARCH_PROFILE)
 include $(arch_profile_dir)/profile.mk
 src_dirs+=$(arch_profile_dir)

--- a/src/arch/armv8/armv8-a/profile.mk
+++ b/src/arch/armv8/armv8-a/profile.mk
@@ -6,5 +6,4 @@ arch-cflags+= -march=armv8-a
 arch-asflags+=
 arch-ldflags+=
 
-arch_mem_prot:=mmu
 PAGE_SIZE:=0x1000

--- a/src/arch/armv8/armv8-r/profile.mk
+++ b/src/arch/armv8/armv8-r/profile.mk
@@ -6,5 +6,4 @@ arch-cflags+=-march=armv8-r
 arch-asflags+=
 arch-ldflags+=
 
-arch_mem_prot:=mpu
 PAGE_SIZE:=64

--- a/src/arch/rh850/Kconfig
+++ b/src/arch/rh850/Kconfig
@@ -1,0 +1,8 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config ARCH_RH850
+	bool
+
+config ARCH
+	default "rh850" if ARCH_RH850

--- a/src/arch/rh850/Kconfig
+++ b/src/arch/rh850/Kconfig
@@ -6,3 +6,9 @@ config ARCH_RH850
 
 config ARCH
 	default "rh850" if ARCH_RH850
+
+config MEM_PROT_MPU
+	default y if ARCH_RH850
+
+config PHYS_IRQS_ONLY
+	default y if ARCH_RH850

--- a/src/arch/rh850/arch.mk
+++ b/src/arch/rh850/arch.mk
@@ -16,6 +16,4 @@ arch-asflags+=-mv850e3v5
 arch-asflags+=-mrh850-abi
 arch-asflags+=-m8byte-align
 
-arch_mem_prot:=mpu
-phys_irqs_only:=y
 PAGE_SIZE:=64

--- a/src/arch/riscv/Kconfig
+++ b/src/arch/riscv/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config ARCH_RISCV
+	bool
+
+config ARCH
+	default "riscv" if ARCH_RISCV
+
+config IRQC
+	string
+
+config IPIC
+	string

--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -43,7 +43,6 @@ arch-cflags = -mcmodel=medany -march=$(riscv_march) -mstrict-align \
 arch-asflags =
 arch-ldflags = -m $(ld_emulation)
 
-arch_mem_prot:=mmu
 PAGE_SIZE:=0x1000
 
 clang_arch_target:=riscv64

--- a/src/arch/riscv/arch.mk
+++ b/src/arch/riscv/arch.mk
@@ -1,7 +1,6 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-ARCH_SUB?=riscv64
 
 ifeq ($(ARCH_SUB), riscv64)
 CROSS_COMPILE ?= riscv64-unknown-elf-

--- a/src/arch/tricore/Kconfig
+++ b/src/arch/tricore/Kconfig
@@ -1,0 +1,8 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config ARCH_TRICORE
+	bool
+
+config ARCH
+	default "tricore" if ARCH_TRICORE

--- a/src/arch/tricore/Kconfig
+++ b/src/arch/tricore/Kconfig
@@ -6,3 +6,12 @@ config ARCH_TRICORE
 
 config ARCH
 	default "tricore" if ARCH_TRICORE
+
+config MEM_PROT_MPU
+	default y if ARCH_TRICORE
+
+config MEM_NON_UNIFIED
+	default y if ARCH_TRICORE
+
+config PHYS_IRQS_ONLY
+	default y if ARCH_TRICORE

--- a/src/arch/tricore/Kconfig
+++ b/src/arch/tricore/Kconfig
@@ -15,3 +15,6 @@ config MEM_NON_UNIFIED
 
 config PHYS_IRQS_ONLY
 	default y if ARCH_TRICORE
+
+config MMIO_SLAVE_SIDE_PROT
+	default y if ARCH_TRICORE

--- a/src/arch/tricore/arch.mk
+++ b/src/arch/tricore/arch.mk
@@ -8,8 +8,4 @@ clang_arch_target:=tricore-unknown-unknown-elf
 arch-cppflags+=
 arch-ldflags=
 
-arch_mem_prot:=mpu
-phys_irqs_only:=y
-plat_mem:=non_unified
 PAGE_SIZE:=64
-mmio_slave_side_prot:=y

--- a/src/core/Kconfig
+++ b/src/core/Kconfig
@@ -1,0 +1,27 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+menu "Core features"
+
+config IPC
+	bool "Inter-VM communication"
+	default y
+	help
+	  Inter-VM communication via shared memory
+	  Includes the associated notification hypercalls.
+
+config MMIO_SLAVE_SIDE_PROT
+	bool "MMIO slave-side protection"
+	depends on PLAT_HAS_MMIO_SLAVE_SIDE_PROT && MEM_PROT_MPU
+	help
+	  Enforce MMIO access control at the bus slave side instead of
+	  through MPU entries on the master side.
+
+config IPI_MAX_EVENTS
+	int "Depth of the per-cpu message queue"
+	default 253
+	help
+	  Depth of the per-cpu message queue
+	  The default keeps the cpu interface within a single 4K page.
+
+endmenu

--- a/src/core/inc/cpu.h
+++ b/src/core/inc/cpu.h
@@ -21,21 +21,8 @@ struct cpu_msg {
     uint64_t data;
 };
 
-/*
- * Default keeps struct cpuif within a single 4K page:
- *   253 * sizeof(struct cpu_msg) + sizeof(struct circular_queue)
- *   = 253 * 16 + 48 = 4096 bytes
- *
- * Override on platforms with tighter memory constraints or that need a
- * deeper queue, e.g. -DIPI_MAX_EVENTS=64.
- */
-#define IPI_MAX_EVENTS_DEFAULT (253)
-#ifndef IPI_MAX_EVENTS
-#define IPI_MAX_EVENTS IPI_MAX_EVENTS_DEFAULT
-#endif
-
 struct cpuif {
-    CQ_DEFINE(struct cpu_msg, msgs, IPI_MAX_EVENTS);
+    CQ_DEFINE(struct cpu_msg, msgs, CONFIG_IPI_MAX_EVENTS);
 } __attribute__((aligned(PAGE_SIZE)));
 
 struct vcpu;

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -39,29 +39,56 @@ endchoice
 
 config PLATFORM
 	string
-	default "agilex5" if PLAT_AGILEX5
-	default "e3650" if PLAT_E3650
-	default "fvp-a" if PLAT_FVP_A
-	default "fvp-a-aarch32" if PLAT_FVP_A_AARCH32
-	default "fvp-r" if PLAT_FVP_R
-	default "fvp-r-aarch32" if PLAT_FVP_R_AARCH32
-	default "hikey960" if PLAT_HIKEY960
-	default "imx8mn" if PLAT_IMX8MN
-	default "imx8mp-verdin" if PLAT_IMX8MP_VERDIN
-	default "imx8qm" if PLAT_IMX8QM
-	default "k3-com260" if PLAT_K3_COM260
-	default "mps3-an536" if PLAT_MPS3_AN536
-	default "qemu-aarch64-virt" if PLAT_QEMU_AARCH64_VIRT
-	default "qemu-riscv32-virt" if PLAT_QEMU_RISCV32_VIRT
-	default "qemu-riscv64-virt" if PLAT_QEMU_RISCV64_VIRT
-	default "rh850-u2a16" if PLAT_RH850_U2A16
-	default "rpi4" if PLAT_RPI4
-	default "s32g3" if PLAT_S32G3
-	default "s32z270" if PLAT_S32Z270
-	default "tc4dx" if PLAT_TC4DX
-	default "tx2" if PLAT_TX2
-	default "ultra96" if PLAT_ULTRA96
-	default "zcu102" if PLAT_ZCU102
-	default "zcu104" if PLAT_ZCU104
+
+
+source "src/platform/agilex5/Kconfig"
+source "src/platform/e3650/Kconfig"
+source "src/platform/fvp-a/Kconfig"
+source "src/platform/fvp-a-aarch32/Kconfig"
+source "src/platform/fvp-r/Kconfig"
+source "src/platform/fvp-r-aarch32/Kconfig"
+source "src/platform/hikey960/Kconfig"
+source "src/platform/imx8mn/Kconfig"
+source "src/platform/imx8mp-verdin/Kconfig"
+source "src/platform/imx8qm/Kconfig"
+source "src/platform/k3-com260/Kconfig"
+source "src/platform/mps3-an536/Kconfig"
+source "src/platform/qemu-aarch64-virt/Kconfig"
+source "src/platform/qemu-riscv32-virt/Kconfig"
+source "src/platform/qemu-riscv64-virt/Kconfig"
+source "src/platform/rh850-u2a16/Kconfig"
+source "src/platform/rpi4/Kconfig"
+source "src/platform/s32g3/Kconfig"
+source "src/platform/s32z270/Kconfig"
+source "src/platform/tc4dx/Kconfig"
+source "src/platform/tx2/Kconfig"
+source "src/platform/ultra96/Kconfig"
+source "src/platform/zcu102/Kconfig"
+source "src/platform/zcu104/Kconfig"
+
+# Written once for all platforms: @SYM@ placeholders are expanded to
+# the resolved values by the menuconfig frontend at display time
+comment ""
+
+comment "Architecture: @ARCH@"
+	depends on ARCH != ""
+
+comment "Sub-architecture: @ARCH_SUB@"
+	depends on ARCH_SUB != ""
+
+comment "Architecture profile: @ARCH_PROFILE@"
+	depends on ARCH_PROFILE != ""
+
+comment "CPU: @CPU@"
+	depends on CPU != ""
+
+comment "GIC version: @GIC_VERSION@"
+	depends on GIC_VERSION != ""
+
+comment "Interrupt controller: @IRQC@"
+	depends on IRQC != ""
+
+comment "IPI controller: @IPIC@"
+	depends on IPIC != ""
 
 endmenu

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -1,0 +1,67 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+# Platform registry. Each platform defines its own choice entry in its
+# Kconfig.plat (sourced inside the choice, which the syntax requires to
+# be a separate file) and everything else in its Kconfig.
+
+menu "Platform"
+
+choice
+	prompt "Target platform"
+
+source "src/platform/agilex5/Kconfig.plat"
+source "src/platform/e3650/Kconfig.plat"
+source "src/platform/fvp-a/Kconfig.plat"
+source "src/platform/fvp-a-aarch32/Kconfig.plat"
+source "src/platform/fvp-r/Kconfig.plat"
+source "src/platform/fvp-r-aarch32/Kconfig.plat"
+source "src/platform/hikey960/Kconfig.plat"
+source "src/platform/imx8mn/Kconfig.plat"
+source "src/platform/imx8mp-verdin/Kconfig.plat"
+source "src/platform/imx8qm/Kconfig.plat"
+source "src/platform/k3-com260/Kconfig.plat"
+source "src/platform/mps3-an536/Kconfig.plat"
+source "src/platform/qemu-aarch64-virt/Kconfig.plat"
+source "src/platform/qemu-riscv32-virt/Kconfig.plat"
+source "src/platform/qemu-riscv64-virt/Kconfig.plat"
+source "src/platform/rh850-u2a16/Kconfig.plat"
+source "src/platform/rpi4/Kconfig.plat"
+source "src/platform/s32g3/Kconfig.plat"
+source "src/platform/s32z270/Kconfig.plat"
+source "src/platform/tc4dx/Kconfig.plat"
+source "src/platform/tx2/Kconfig.plat"
+source "src/platform/ultra96/Kconfig.plat"
+source "src/platform/zcu102/Kconfig.plat"
+source "src/platform/zcu104/Kconfig.plat"
+
+endchoice
+
+config PLATFORM
+	string
+	default "agilex5" if PLAT_AGILEX5
+	default "e3650" if PLAT_E3650
+	default "fvp-a" if PLAT_FVP_A
+	default "fvp-a-aarch32" if PLAT_FVP_A_AARCH32
+	default "fvp-r" if PLAT_FVP_R
+	default "fvp-r-aarch32" if PLAT_FVP_R_AARCH32
+	default "hikey960" if PLAT_HIKEY960
+	default "imx8mn" if PLAT_IMX8MN
+	default "imx8mp-verdin" if PLAT_IMX8MP_VERDIN
+	default "imx8qm" if PLAT_IMX8QM
+	default "k3-com260" if PLAT_K3_COM260
+	default "mps3-an536" if PLAT_MPS3_AN536
+	default "qemu-aarch64-virt" if PLAT_QEMU_AARCH64_VIRT
+	default "qemu-riscv32-virt" if PLAT_QEMU_RISCV32_VIRT
+	default "qemu-riscv64-virt" if PLAT_QEMU_RISCV64_VIRT
+	default "rh850-u2a16" if PLAT_RH850_U2A16
+	default "rpi4" if PLAT_RPI4
+	default "s32g3" if PLAT_S32G3
+	default "s32z270" if PLAT_S32Z270
+	default "tc4dx" if PLAT_TC4DX
+	default "tx2" if PLAT_TX2
+	default "ultra96" if PLAT_ULTRA96
+	default "zcu102" if PLAT_ZCU102
+	default "zcu104" if PLAT_ZCU104
+
+endmenu

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -40,6 +40,15 @@ endchoice
 config PLATFORM
 	string
 
+config MEM_NON_UNIFIED
+	bool
+	help
+	  Split instruction and data memory buses with separate hypervisor
+	  images per memory - fixed by the platform.
+
+config PLAT_HAS_MMIO_SLAVE_SIDE_PROT
+	bool
+
 
 source "src/platform/agilex5/Kconfig"
 source "src/platform/e3650/Kconfig"
@@ -90,5 +99,11 @@ comment "Interrupt controller: @IRQC@"
 
 comment "IPI controller: @IPIC@"
 	depends on IPIC != ""
+
+comment "Memory model: non-unified"
+	depends on MEM_NON_UNIFIED
+
+comment "Physical interrupts only"
+	depends on PHYS_IRQS_ONLY
 
 endmenu

--- a/src/platform/agilex5/Kconfig
+++ b/src/platform/agilex5/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "agilex5" if PLAT_AGILEX5
+
+config ARCH_SUB
+	default "aarch64" if PLAT_AGILEX5
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_AGILEX5
+
+config CPU
+	default "cortex-a55" if PLAT_AGILEX5
+
+config GIC_VERSION
+	default "GICV3" if PLAT_AGILEX5

--- a/src/platform/agilex5/Kconfig.plat
+++ b/src/platform/agilex5/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_AGILEX5
 	bool "agilex5"
+	select ARCH_ARMV8

--- a/src/platform/agilex5/Kconfig.plat
+++ b/src/platform/agilex5/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_AGILEX5
+	bool "agilex5"

--- a/src/platform/agilex5/platform.mk
+++ b/src/platform/agilex5/platform.mk
@@ -1,12 +1,8 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
 # big.LITTLE (2x A76 + 2x A55); tune for A55 as the common baseline
-CPU:=cortex-a55
 
-GIC_VERSION:=GICV3
 
 # Board DDR capacity in GiB; selects mem_regions in agilex5_desc.c.
 # Override via configs/<CONFIG>/config.mk or the make command line.

--- a/src/platform/e3650/Kconfig
+++ b/src/platform/e3650/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "e3650" if PLAT_E3650
+
+config ARCH_SUB
+	default "aarch32" if PLAT_E3650
+
+config ARCH_PROFILE
+	default "armv8-r" if PLAT_E3650
+
+config GIC_VERSION
+	default "GICV3" if PLAT_E3650

--- a/src/platform/e3650/Kconfig.plat
+++ b/src/platform/e3650/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_E3650
 	bool "e3650"
+	select ARCH_ARMV8

--- a/src/platform/e3650/Kconfig.plat
+++ b/src/platform/e3650/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_E3650
+	bool "e3650"

--- a/src/platform/e3650/platform.mk
+++ b/src/platform/e3650/platform.mk
@@ -1,14 +1,9 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-ARCH_PROFILE:=armv8-r
-ARCH_SUB:=aarch32
 
 PLAT_CPUS:=cortex_r52
 
-GIC_VERSION:=GICV3
 
 drivers=e3650_uart
 

--- a/src/platform/fvp-a-aarch32/Kconfig
+++ b/src/platform/fvp-a-aarch32/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "fvp-a-aarch32" if PLAT_FVP_A_AARCH32
+
+config ARCH_SUB
+	default "aarch32" if PLAT_FVP_A_AARCH32
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_FVP_A_AARCH32
+
+config GIC_VERSION
+	default "GICV3" if PLAT_FVP_A_AARCH32

--- a/src/platform/fvp-a-aarch32/Kconfig.plat
+++ b/src/platform/fvp-a-aarch32/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_FVP_A_AARCH32
+	bool "fvp-a-aarch32"

--- a/src/platform/fvp-a-aarch32/Kconfig.plat
+++ b/src/platform/fvp-a-aarch32/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_FVP_A_AARCH32
 	bool "fvp-a-aarch32"
+	select ARCH_ARMV8

--- a/src/platform/fvp-a-aarch32/platform.mk
+++ b/src/platform/fvp-a-aarch32/platform.mk
@@ -1,5 +1,4 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-ARCH_SUB:=aarch32
 include $(current_directory)/../fvp-a/platform.mk

--- a/src/platform/fvp-a/Kconfig
+++ b/src/platform/fvp-a/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "fvp-a" if PLAT_FVP_A
+
+config ARCH_SUB
+	default "aarch64" if PLAT_FVP_A
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_FVP_A
+
+config GIC_VERSION
+	default "GICV3" if PLAT_FVP_A

--- a/src/platform/fvp-a/Kconfig.plat
+++ b/src/platform/fvp-a/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_FVP_A
+	bool "fvp-a"

--- a/src/platform/fvp-a/Kconfig.plat
+++ b/src/platform/fvp-a/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_FVP_A
 	bool "fvp-a"
+	select ARCH_ARMV8

--- a/src/platform/fvp-a/platform.mk
+++ b/src/platform/fvp-a/platform.mk
@@ -1,10 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
 
-GIC_VERSION:=GICV3
 
 drivers = pl011_uart
 

--- a/src/platform/fvp-r-aarch32/Kconfig
+++ b/src/platform/fvp-r-aarch32/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "fvp-r-aarch32" if PLAT_FVP_R_AARCH32
+
+config ARCH_SUB
+	default "aarch32" if PLAT_FVP_R_AARCH32
+
+config ARCH_PROFILE
+	default "armv8-r" if PLAT_FVP_R_AARCH32
+
+config GIC_VERSION
+	default "GICV3" if PLAT_FVP_R_AARCH32

--- a/src/platform/fvp-r-aarch32/Kconfig.plat
+++ b/src/platform/fvp-r-aarch32/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_FVP_R_AARCH32
+	bool "fvp-r-aarch32"

--- a/src/platform/fvp-r-aarch32/Kconfig.plat
+++ b/src/platform/fvp-r-aarch32/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_FVP_R_AARCH32
 	bool "fvp-r-aarch32"
+	select ARCH_ARMV8

--- a/src/platform/fvp-r-aarch32/platform.mk
+++ b/src/platform/fvp-r-aarch32/platform.mk
@@ -1,5 +1,4 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-ARCH_SUB:=aarch32
 include $(current_directory)/../fvp-r/platform.mk

--- a/src/platform/fvp-r/Kconfig
+++ b/src/platform/fvp-r/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "fvp-r" if PLAT_FVP_R
+
+config ARCH_SUB
+	default "aarch64" if PLAT_FVP_R
+
+config ARCH_PROFILE
+	default "armv8-r" if PLAT_FVP_R
+
+config GIC_VERSION
+	default "GICV3" if PLAT_FVP_R

--- a/src/platform/fvp-r/Kconfig.plat
+++ b/src/platform/fvp-r/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_FVP_R
 	bool "fvp-r"
+	select ARCH_ARMV8

--- a/src/platform/fvp-r/Kconfig.plat
+++ b/src/platform/fvp-r/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_FVP_R
+	bool "fvp-r"

--- a/src/platform/fvp-r/platform.mk
+++ b/src/platform/fvp-r/platform.mk
@@ -1,11 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-ARCH_PROFILE:=armv8-r
 
-GIC_VERSION:=GICV3
 
 drivers = pl011_uart
 

--- a/src/platform/hikey960/Kconfig
+++ b/src/platform/hikey960/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "hikey960" if PLAT_HIKEY960
+
+config ARCH_SUB
+	default "aarch64" if PLAT_HIKEY960
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_HIKEY960
+
+config CPU
+	default "cortex-a53" if PLAT_HIKEY960
+
+config GIC_VERSION
+	default "GICV2" if PLAT_HIKEY960

--- a/src/platform/hikey960/Kconfig.plat
+++ b/src/platform/hikey960/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_HIKEY960
+	bool "hikey960"

--- a/src/platform/hikey960/Kconfig.plat
+++ b/src/platform/hikey960/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_HIKEY960
 	bool "hikey960"
+	select ARCH_ARMV8

--- a/src/platform/hikey960/platform.mk
+++ b/src/platform/hikey960/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV2
 
 drivers = pl011_uart
 

--- a/src/platform/imx8mn/Kconfig
+++ b/src/platform/imx8mn/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "imx8mn" if PLAT_IMX8MN
+
+config ARCH_SUB
+	default "aarch64" if PLAT_IMX8MN
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_IMX8MN
+
+config CPU
+	default "cortex-a53" if PLAT_IMX8MN
+
+config GIC_VERSION
+	default "GICV3" if PLAT_IMX8MN

--- a/src/platform/imx8mn/Kconfig.plat
+++ b/src/platform/imx8mn/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_IMX8MN
+	bool "imx8mn"

--- a/src/platform/imx8mn/Kconfig.plat
+++ b/src/platform/imx8mn/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_IMX8MN
 	bool "imx8mn"
+	select ARCH_ARMV8

--- a/src/platform/imx8mn/platform.mk
+++ b/src/platform/imx8mn/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV3
 
 drivers = imx_uart
 

--- a/src/platform/imx8mp-verdin/Kconfig
+++ b/src/platform/imx8mp-verdin/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "imx8mp-verdin" if PLAT_IMX8MP_VERDIN
+
+config ARCH_SUB
+	default "aarch64" if PLAT_IMX8MP_VERDIN
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_IMX8MP_VERDIN
+
+config CPU
+	default "cortex-a53" if PLAT_IMX8MP_VERDIN
+
+config GIC_VERSION
+	default "GICV3" if PLAT_IMX8MP_VERDIN

--- a/src/platform/imx8mp-verdin/Kconfig.plat
+++ b/src/platform/imx8mp-verdin/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_IMX8MP_VERDIN
+	bool "imx8mp-verdin"

--- a/src/platform/imx8mp-verdin/Kconfig.plat
+++ b/src/platform/imx8mp-verdin/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_IMX8MP_VERDIN
 	bool "imx8mp-verdin"
+	select ARCH_ARMV8

--- a/src/platform/imx8mp-verdin/platform.mk
+++ b/src/platform/imx8mp-verdin/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV3
 
 drivers = imx_uart
 

--- a/src/platform/imx8qm/Kconfig
+++ b/src/platform/imx8qm/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "imx8qm" if PLAT_IMX8QM
+
+config ARCH_SUB
+	default "aarch64" if PLAT_IMX8QM
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_IMX8QM
+
+config CPU
+	default "cortex-a53" if PLAT_IMX8QM
+
+config GIC_VERSION
+	default "GICV3" if PLAT_IMX8QM

--- a/src/platform/imx8qm/Kconfig.plat
+++ b/src/platform/imx8qm/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_IMX8QM
+	bool "imx8qm"

--- a/src/platform/imx8qm/Kconfig.plat
+++ b/src/platform/imx8qm/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_IMX8QM
 	bool "imx8qm"
+	select ARCH_ARMV8

--- a/src/platform/imx8qm/platform.mk
+++ b/src/platform/imx8qm/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV3
 
 drivers = nxp_uart
 

--- a/src/platform/k3-com260/Kconfig
+++ b/src/platform/k3-com260/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "k3-com260" if PLAT_K3_COM260
+
+config ARCH_SUB
+	default "riscv64" if PLAT_K3_COM260
+
+config IRQC
+	default "AIA" if PLAT_K3_COM260
+
+config IPIC
+	default "IPIC_SBI" if PLAT_K3_COM260

--- a/src/platform/k3-com260/Kconfig.plat
+++ b/src/platform/k3-com260/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_K3_COM260
 	bool "k3-com260"
+	select ARCH_RISCV

--- a/src/platform/k3-com260/Kconfig.plat
+++ b/src/platform/k3-com260/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_K3_COM260
+	bool "k3-com260"

--- a/src/platform/k3-com260/platform.mk
+++ b/src/platform/k3-com260/platform.mk
@@ -7,14 +7,8 @@
 # (H) extension, so Bao runs on those. The A100 harts (cpu@8-15) lack H and are
 # intentionally left out of the platform description.
 
-# Architecture definition
-ARCH:=riscv
-# CPU definition
-CPU:=
 # Interrupt controller definition (Advanced Interrupt Architecture: APLIC + IMSIC)
-IRQC:=AIA
 # Core IPIs controller (SBI IPI, provided by the resident M-mode OpenSBI)
-IPIC:=IPIC_SBI
 
 # The hypervisor drives the K3 UART0 directly for its own debug output. The K3
 # UART (spacemit,k1-uart / intel,xscale-uart) is a 16550/8250-compatible block

--- a/src/platform/mps3-an536/Kconfig
+++ b/src/platform/mps3-an536/Kconfig
@@ -1,0 +1,27 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "mps3-an536" if PLAT_MPS3_AN536
+
+config ARCH_SUB
+	default "aarch32" if PLAT_MPS3_AN536
+
+config ARCH_PROFILE
+	default "armv8-r" if PLAT_MPS3_AN536
+
+choice
+	prompt "GIC version"
+	depends on PLAT_MPS3_AN536
+
+config MPS3_AN536_GIC_V3
+	bool "GICv3"
+
+config MPS3_AN536_GIC_V2
+	bool "GICv2"
+
+endchoice
+
+config GIC_VERSION
+	default "GICV3" if MPS3_AN536_GIC_V3
+	default "GICV2" if MPS3_AN536_GIC_V2

--- a/src/platform/mps3-an536/Kconfig.plat
+++ b/src/platform/mps3-an536/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_MPS3_AN536
+	bool "mps3-an536"

--- a/src/platform/mps3-an536/Kconfig.plat
+++ b/src/platform/mps3-an536/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_MPS3_AN536
 	bool "mps3-an536"
+	select ARCH_ARMV8

--- a/src/platform/mps3-an536/platform.mk
+++ b/src/platform/mps3-an536/platform.mk
@@ -2,11 +2,7 @@
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
 
-ARCH:=armv8
-ARCH_SUB:=aarch32
-ARCH_PROFILE:=armv8-r
 
-GIC_VERSION:=GICV3
 
 drivers = cmsdk_uart
 

--- a/src/platform/qemu-aarch64-virt/Kconfig
+++ b/src/platform/qemu-aarch64-virt/Kconfig
@@ -1,0 +1,30 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "qemu-aarch64-virt" if PLAT_QEMU_AARCH64_VIRT
+
+config ARCH_SUB
+	default "aarch64" if PLAT_QEMU_AARCH64_VIRT
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_QEMU_AARCH64_VIRT
+
+config CPU
+	default "cortex-a53" if PLAT_QEMU_AARCH64_VIRT
+
+choice
+	prompt "GIC version"
+	depends on PLAT_QEMU_AARCH64_VIRT
+
+config QEMU_AARCH64_VIRT_GIC_V3
+	bool "GICv3"
+
+config QEMU_AARCH64_VIRT_GIC_V2
+	bool "GICv2"
+
+endchoice
+
+config GIC_VERSION
+	default "GICV3" if QEMU_AARCH64_VIRT_GIC_V3
+	default "GICV2" if QEMU_AARCH64_VIRT_GIC_V2

--- a/src/platform/qemu-aarch64-virt/Kconfig.plat
+++ b/src/platform/qemu-aarch64-virt/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_QEMU_AARCH64_VIRT
 	bool "qemu-aarch64-virt"
+	select ARCH_ARMV8

--- a/src/platform/qemu-aarch64-virt/Kconfig.plat
+++ b/src/platform/qemu-aarch64-virt/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_QEMU_AARCH64_VIRT
+	bool "qemu-aarch64-virt"

--- a/src/platform/qemu-aarch64-virt/platform.mk
+++ b/src/platform/qemu-aarch64-virt/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV3
 
 drivers = pl011_uart
 

--- a/src/platform/qemu-riscv32-virt/Kconfig
+++ b/src/platform/qemu-riscv32-virt/Kconfig
@@ -7,8 +7,34 @@ config PLATFORM
 config ARCH_SUB
 	default "riscv32" if PLAT_QEMU_RISCV32_VIRT
 
+choice
+	prompt "Interrupt controller"
+	depends on PLAT_QEMU_RISCV32_VIRT
+
+config QEMU_RISCV32_VIRT_IRQC_AIA
+	bool "AIA"
+
+config QEMU_RISCV32_VIRT_IRQC_PLIC
+	bool "PLIC"
+
+endchoice
+
 config IRQC
-	default "AIA" if PLAT_QEMU_RISCV32_VIRT
+	default "AIA" if QEMU_RISCV32_VIRT_IRQC_AIA
+	default "PLIC" if QEMU_RISCV32_VIRT_IRQC_PLIC
+
+choice
+	prompt "IPI controller"
+	depends on PLAT_QEMU_RISCV32_VIRT
+
+config QEMU_RISCV32_VIRT_IPIC_SBI
+	bool "SBI"
+
+config QEMU_RISCV32_VIRT_IPIC_ACLINT
+	bool "ACLINT"
+
+endchoice
 
 config IPIC
-	default "IPIC_SBI" if PLAT_QEMU_RISCV32_VIRT
+	default "IPIC_SBI" if QEMU_RISCV32_VIRT_IPIC_SBI
+	default "IPIC_ACLINT" if QEMU_RISCV32_VIRT_IPIC_ACLINT

--- a/src/platform/qemu-riscv32-virt/Kconfig
+++ b/src/platform/qemu-riscv32-virt/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "qemu-riscv32-virt" if PLAT_QEMU_RISCV32_VIRT
+
+config ARCH_SUB
+	default "riscv32" if PLAT_QEMU_RISCV32_VIRT
+
+config IRQC
+	default "AIA" if PLAT_QEMU_RISCV32_VIRT
+
+config IPIC
+	default "IPIC_SBI" if PLAT_QEMU_RISCV32_VIRT

--- a/src/platform/qemu-riscv32-virt/Kconfig.plat
+++ b/src/platform/qemu-riscv32-virt/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_QEMU_RISCV32_VIRT
 	bool "qemu-riscv32-virt"
+	select ARCH_RISCV

--- a/src/platform/qemu-riscv32-virt/Kconfig.plat
+++ b/src/platform/qemu-riscv32-virt/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_QEMU_RISCV32_VIRT
+	bool "qemu-riscv32-virt"

--- a/src/platform/qemu-riscv32-virt/platform.mk
+++ b/src/platform/qemu-riscv32-virt/platform.mk
@@ -1,5 +1,4 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-ARCH_SUB:=riscv32
 include $(current_directory)/../qemu-riscv64-virt/platform.mk

--- a/src/platform/qemu-riscv64-virt/Kconfig
+++ b/src/platform/qemu-riscv64-virt/Kconfig
@@ -7,8 +7,34 @@ config PLATFORM
 config ARCH_SUB
 	default "riscv64" if PLAT_QEMU_RISCV64_VIRT
 
+choice
+	prompt "Interrupt controller"
+	depends on PLAT_QEMU_RISCV64_VIRT
+
+config QEMU_RISCV64_VIRT_IRQC_AIA
+	bool "AIA"
+
+config QEMU_RISCV64_VIRT_IRQC_PLIC
+	bool "PLIC"
+
+endchoice
+
 config IRQC
-	default "AIA" if PLAT_QEMU_RISCV64_VIRT
+	default "AIA" if QEMU_RISCV64_VIRT_IRQC_AIA
+	default "PLIC" if QEMU_RISCV64_VIRT_IRQC_PLIC
+
+choice
+	prompt "IPI controller"
+	depends on PLAT_QEMU_RISCV64_VIRT
+
+config QEMU_RISCV64_VIRT_IPIC_SBI
+	bool "SBI"
+
+config QEMU_RISCV64_VIRT_IPIC_ACLINT
+	bool "ACLINT"
+
+endchoice
 
 config IPIC
-	default "IPIC_SBI" if PLAT_QEMU_RISCV64_VIRT
+	default "IPIC_SBI" if QEMU_RISCV64_VIRT_IPIC_SBI
+	default "IPIC_ACLINT" if QEMU_RISCV64_VIRT_IPIC_ACLINT

--- a/src/platform/qemu-riscv64-virt/Kconfig
+++ b/src/platform/qemu-riscv64-virt/Kconfig
@@ -1,0 +1,14 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "qemu-riscv64-virt" if PLAT_QEMU_RISCV64_VIRT
+
+config ARCH_SUB
+	default "riscv64" if PLAT_QEMU_RISCV64_VIRT
+
+config IRQC
+	default "AIA" if PLAT_QEMU_RISCV64_VIRT
+
+config IPIC
+	default "IPIC_SBI" if PLAT_QEMU_RISCV64_VIRT

--- a/src/platform/qemu-riscv64-virt/Kconfig.plat
+++ b/src/platform/qemu-riscv64-virt/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_QEMU_RISCV64_VIRT
+	bool "qemu-riscv64-virt"

--- a/src/platform/qemu-riscv64-virt/Kconfig.plat
+++ b/src/platform/qemu-riscv64-virt/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_QEMU_RISCV64_VIRT
 	bool "qemu-riscv64-virt"
+	select ARCH_RISCV

--- a/src/platform/qemu-riscv64-virt/platform.mk
+++ b/src/platform/qemu-riscv64-virt/platform.mk
@@ -1,14 +1,6 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=riscv
-# CPU definition
-CPU:=
-# Interrupt controller definition
-IRQC:=AIA
-# Core IPIs controller
-IPIC:=IPIC_SBI
 
 drivers := sbi_uart
 

--- a/src/platform/rh850-u2a16/Kconfig
+++ b/src/platform/rh850-u2a16/Kconfig
@@ -7,3 +7,6 @@ config PLATFORM
 config ARCH_PROFILE
 	default "main" if PLAT_RH850_U2A16
 
+
+config MEM_NON_UNIFIED
+	default y if PLAT_RH850_U2A16

--- a/src/platform/rh850-u2a16/Kconfig
+++ b/src/platform/rh850-u2a16/Kconfig
@@ -1,0 +1,9 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "rh850-u2a16" if PLAT_RH850_U2A16
+
+config ARCH_PROFILE
+	default "main" if PLAT_RH850_U2A16
+

--- a/src/platform/rh850-u2a16/Kconfig.plat
+++ b/src/platform/rh850-u2a16/Kconfig.plat
@@ -4,3 +4,4 @@
 config PLAT_RH850_U2A16
 	bool "rh850-u2a16"
 	select ARCH_RH850
+	select PLAT_HAS_MMIO_SLAVE_SIDE_PROT

--- a/src/platform/rh850-u2a16/Kconfig.plat
+++ b/src/platform/rh850-u2a16/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_RH850_U2A16
+	bool "rh850-u2a16"

--- a/src/platform/rh850-u2a16/Kconfig.plat
+++ b/src/platform/rh850-u2a16/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_RH850_U2A16
 	bool "rh850-u2a16"
+	select ARCH_RH850

--- a/src/platform/rh850-u2a16/platform.mk
+++ b/src/platform/rh850-u2a16/platform.mk
@@ -1,9 +1,6 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=rh850
-ARCH_PROFILE:=main
 drivers:=renesas_rlin3
 
 platform_description:=u2a16_desc.c

--- a/src/platform/rh850-u2a16/platform.mk
+++ b/src/platform/rh850-u2a16/platform.mk
@@ -10,4 +10,3 @@ platform-cflags = -gdwarf-4
 platform-asflags = -gdwarf-4
 platform-ldflags =
 
-plat_mem:=non_unified

--- a/src/platform/rpi4/Kconfig
+++ b/src/platform/rpi4/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "rpi4" if PLAT_RPI4
+
+config ARCH_SUB
+	default "aarch64" if PLAT_RPI4
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_RPI4
+
+config CPU
+	default "cortex-a72" if PLAT_RPI4
+
+config GIC_VERSION
+	default "GICV2" if PLAT_RPI4

--- a/src/platform/rpi4/Kconfig.plat
+++ b/src/platform/rpi4/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_RPI4
 	bool "rpi4"
+	select ARCH_ARMV8

--- a/src/platform/rpi4/Kconfig.plat
+++ b/src/platform/rpi4/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_RPI4
+	bool "rpi4"

--- a/src/platform/rpi4/platform.mk
+++ b/src/platform/rpi4/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a72
 
-GIC_VERSION:=GICV2
 RPI4_MEM_GB:=4
 
 drivers = 8250_uart

--- a/src/platform/s32g3/Kconfig
+++ b/src/platform/s32g3/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "s32g3" if PLAT_S32G3
+
+config ARCH_SUB
+	default "aarch64" if PLAT_S32G3
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_S32G3
+
+config CPU
+	default "cortex-a53" if PLAT_S32G3
+
+config GIC_VERSION
+	default "GICV3" if PLAT_S32G3

--- a/src/platform/s32g3/Kconfig.plat
+++ b/src/platform/s32g3/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_S32G3
+	bool "s32g3"

--- a/src/platform/s32g3/Kconfig.plat
+++ b/src/platform/s32g3/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_S32G3
 	bool "s32g3"
+	select ARCH_ARMV8

--- a/src/platform/s32g3/platform.mk
+++ b/src/platform/s32g3/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV3
 
 drivers = linflexd_uart
 

--- a/src/platform/s32z270/Kconfig
+++ b/src/platform/s32z270/Kconfig
@@ -13,3 +13,6 @@ config ARCH_PROFILE
 config GIC_VERSION
 	default "GICV3" if PLAT_S32Z270
 
+
+config MEM_NON_UNIFIED
+	default y if PLAT_S32Z270

--- a/src/platform/s32z270/Kconfig
+++ b/src/platform/s32z270/Kconfig
@@ -1,0 +1,15 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "s32z270" if PLAT_S32Z270
+
+config ARCH_SUB
+	default "aarch32" if PLAT_S32Z270
+
+config ARCH_PROFILE
+	default "armv8-r" if PLAT_S32Z270
+
+config GIC_VERSION
+	default "GICV3" if PLAT_S32Z270
+

--- a/src/platform/s32z270/Kconfig.plat
+++ b/src/platform/s32z270/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_S32Z270
+	bool "s32z270"

--- a/src/platform/s32z270/Kconfig.plat
+++ b/src/platform/s32z270/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_S32Z270
 	bool "s32z270"
+	select ARCH_ARMV8

--- a/src/platform/s32z270/platform.mk
+++ b/src/platform/s32z270/platform.mk
@@ -1,14 +1,9 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-ARCH_PROFILE:=armv8-r
-ARCH_SUB:=aarch32
 
 PLAT_CPUS:=cortex_r52
 
-GIC_VERSION:=GICV3
 
 drivers = linflexd_uart
 

--- a/src/platform/s32z270/platform.mk
+++ b/src/platform/s32z270/platform.mk
@@ -9,7 +9,6 @@ drivers = linflexd_uart
 
 platform_description:=s32z270_desc.c
 
-plat_mem:=non_unified
 
 platform-cppflags =
 platform-cflags =

--- a/src/platform/tc4dx/Kconfig
+++ b/src/platform/tc4dx/Kconfig
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "tc4dx" if PLAT_TC4DX

--- a/src/platform/tc4dx/Kconfig.plat
+++ b/src/platform/tc4dx/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_TC4DX
+	bool "tc4dx"

--- a/src/platform/tc4dx/Kconfig.plat
+++ b/src/platform/tc4dx/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_TC4DX
 	bool "tc4dx"
+	select ARCH_TRICORE

--- a/src/platform/tc4dx/Kconfig.plat
+++ b/src/platform/tc4dx/Kconfig.plat
@@ -4,3 +4,4 @@
 config PLAT_TC4DX
 	bool "tc4dx"
 	select ARCH_TRICORE
+	select PLAT_HAS_MMIO_SLAVE_SIDE_PROT

--- a/src/platform/tc4dx/platform.mk
+++ b/src/platform/tc4dx/platform.mk
@@ -1,8 +1,6 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=tricore
 
 drivers = asclin_uart
 

--- a/src/platform/tx2/Kconfig
+++ b/src/platform/tx2/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "tx2" if PLAT_TX2
+
+config ARCH_SUB
+	default "aarch64" if PLAT_TX2
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_TX2
+
+config CPU
+	default "cortex-a57" if PLAT_TX2
+
+config GIC_VERSION
+	default "GICV2" if PLAT_TX2

--- a/src/platform/tx2/Kconfig.plat
+++ b/src/platform/tx2/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_TX2
+	bool "tx2"

--- a/src/platform/tx2/Kconfig.plat
+++ b/src/platform/tx2/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_TX2
 	bool "tx2"
+	select ARCH_ARMV8

--- a/src/platform/tx2/platform.mk
+++ b/src/platform/tx2/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a57
 
-GIC_VERSION:=GICV2
 
 # TODO: Driver missing, should be 8250 compatible
 drivers = 8250_uart

--- a/src/platform/ultra96/Kconfig
+++ b/src/platform/ultra96/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "ultra96" if PLAT_ULTRA96
+
+config ARCH_SUB
+	default "aarch64" if PLAT_ULTRA96
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_ULTRA96
+
+config CPU
+	default "cortex-a53" if PLAT_ULTRA96
+
+config GIC_VERSION
+	default "GICV2" if PLAT_ULTRA96

--- a/src/platform/ultra96/Kconfig.plat
+++ b/src/platform/ultra96/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_ULTRA96
+	bool "ultra96"

--- a/src/platform/ultra96/Kconfig.plat
+++ b/src/platform/ultra96/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_ULTRA96
 	bool "ultra96"
+	select ARCH_ARMV8

--- a/src/platform/ultra96/platform.mk
+++ b/src/platform/ultra96/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV2
 
 drivers = zynq_uart
 

--- a/src/platform/zcu102/Kconfig
+++ b/src/platform/zcu102/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "zcu102" if PLAT_ZCU102
+
+config ARCH_SUB
+	default "aarch64" if PLAT_ZCU102
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_ZCU102
+
+config CPU
+	default "cortex-a53" if PLAT_ZCU102
+
+config GIC_VERSION
+	default "GICV2" if PLAT_ZCU102

--- a/src/platform/zcu102/Kconfig.plat
+++ b/src/platform/zcu102/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_ZCU102
+	bool "zcu102"

--- a/src/platform/zcu102/Kconfig.plat
+++ b/src/platform/zcu102/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_ZCU102
 	bool "zcu102"
+	select ARCH_ARMV8

--- a/src/platform/zcu102/platform.mk
+++ b/src/platform/zcu102/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV2
 
 drivers = zynq_uart
 

--- a/src/platform/zcu104/Kconfig
+++ b/src/platform/zcu104/Kconfig
@@ -1,0 +1,17 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLATFORM
+	default "zcu104" if PLAT_ZCU104
+
+config ARCH_SUB
+	default "aarch64" if PLAT_ZCU104
+
+config ARCH_PROFILE
+	default "armv8-a" if PLAT_ZCU104
+
+config CPU
+	default "cortex-a53" if PLAT_ZCU104
+
+config GIC_VERSION
+	default "GICV2" if PLAT_ZCU104

--- a/src/platform/zcu104/Kconfig.plat
+++ b/src/platform/zcu104/Kconfig.plat
@@ -1,0 +1,5 @@
+## SPDX-License-Identifier: Apache-2.0
+## Copyright (c) Bao Project and Contributors. All rights reserved.
+
+config PLAT_ZCU104
+	bool "zcu104"

--- a/src/platform/zcu104/Kconfig.plat
+++ b/src/platform/zcu104/Kconfig.plat
@@ -3,3 +3,4 @@
 
 config PLAT_ZCU104
 	bool "zcu104"
+	select ARCH_ARMV8

--- a/src/platform/zcu104/platform.mk
+++ b/src/platform/zcu104/platform.mk
@@ -1,12 +1,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ## Copyright (c) Bao Project and Contributors. All rights reserved.
 
-# Architecture definition
-ARCH:=armv8
-# CPU definition
-CPU:=cortex-a53
 
-GIC_VERSION:=GICV2
 
 drivers = zynq_uart
 


### PR DESCRIPTION
This PR introduces a Kconfig-based configuration system for bao's build. It replaces scattered make variables and command-line `-D` macros with a structured, validated configuration tree, while keeping the familiar `make PLATFORM=<plat> CONFIG=<config>` entry point unchanged.

## How options split between config.c and Kconfig

The guiding rule is that config.c describes the deployment (which VMs run, their images, memory regions, device assignments, and per-VM parameters), while Kconfig describes the hypervisor build itself: which features are compiled in, the platform identity and its hardware facts, and build tunables.

The two sides are deliberately coupled at compile time. When a feature is disabled in Kconfig, its fields are removed from the configuration structures rather than silently ignored, so a config.c that sets parameters for a disabled feature fails to build with a compiler error pointing at the offending line. This rule takes effect as features gain gating (see the follow-ups below).

Kconfig symbols fall into three groups:

1. User options: selectable features and tunables, such as `IPC` or `IPI_MAX_EVENTS`, including platform properties a platform may default but allow the user to override, such as `MEM_NON_UNIFIED`.
2. Platform and architecture facts: values fixed by the platform selection (`ARCH`, `ARCH_SUB`, `ARCH_PROFILE`, CPU count, GIC version, `IRQC`/`IPIC`, the memory protection model). They are visible in menuconfig for inspection but not editable, and a defconfig that tries to override one fails the configuration step. Where a platform genuinely offers a hardware choice the fact becomes a real choice: qemu riscv virt can select PLIC, APLIC, or AIA and the matching IPI mechanism.
3. Platform capabilities: promptless `PLAT_HAS_*` symbols that gate which user options are even offered, e.g. MMIO slave-side protection is only offered on platforms that declare support for it.

## Infrastructure

1. A Kconfig tree rooted at `src/Kconfig` sources the architecture trees (`src/arch/*/Kconfig`) and the platform registry (`src/platform/Kconfig`). Each platform contributes its identity and selects (`Kconfig.plat`) plus its fact defaults (`Kconfig`).
2. The resolved `.config` lives per build instance at `build/<plat>/<config>/.config`, so different platform/config pairs never fight over a shared file.
3. Seeding is layered: the platform defconfig (`src/platform/<plat>/defconfig`, when present), then an optional defconfig next to the VM configuration (`configs/<config>/defconfig`), then Kconfig defaults. `PLATFORM=` pins the platform choice.
4. The build consumes two generated artifacts: `auto.conf`, included by make and used to gate objects (`core-objs-$(CONFIG_X)+=...`), and `autoconf.h`, force-included into every compilation unit so code sees `CONFIG_*` macros without explicit includes.
5. `make PLATFORM=<plat> CONFIG=<config> menuconfig` edits the build's configuration interactively; `listconfig` prints every option with its value and which layer decided it (default, platform, config, or modified by the user), plus the fixed facts.
6. Validation is strict: unknown symbols and attempts to set platform-fixed facts are hard errors, and `CONFIG_*` variables cannot be overridden on the make command line; defconfigs and menuconfig are the only configuration inputs.

The engine is kconfiglib driven by `scripts/kconfig.py`, so configuring a build requires python3 with kconfiglib available; all constraints that the build itself depends on remain enforced in the Makefiles.

## What is configurable in this PR, and what comes next

This PR moves the existing platform and architecture build facts into Kconfig (memory protection model, non-unified memory, physical interrupt handling, interrupt controller selection) and introduces the first core feature options: `MMIO_SLAVE_SIDE_PROT` (bridged to the existing `DEFINED()`-based gating), `IPI_MAX_EVENTS` (now sizing the cpu message queue directly, replacing the `-D` override), and `IPC`, whose code gating lands in a follow-up.

Two follow-ups are already prepared on branches stacked on this one, each to become its own PR:

1. Remote I/O (`CONFIG_REMIO`): compiles remio fully out when disabled, including the hypercall dispatch, the VM init hooks, and the remio fields of the configuration structures.
2. Cache coloring (`CONFIG_MEM_COLORING`): MMU-only option that compiles the coloring module out and strips color fields and arguments from disabled builds, moving all coloring logic behind a single `coloring.h` boundary header.

An open question for reviewers: which other build-time knobs should move into Kconfig? Existing `-D` macros, debug and logging options, and per-architecture features are all candidates; input on what is missing from this first set is welcome.
