### PR TITLE
fix(vgic): break the no-pending maintenance storm when all LRs are active

### DIFF
--- a/src/arch/armv8/inc/arch/vgic.h
+++ b/src/arch/armv8/inc/arch/vgic.h
@@ -47,6 +47,7 @@ struct vgic_int {
 #endif
     bool hw;
     bool in_lr;
+    bool in_spilled;
     bool enabled;
 };
 

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -180,7 +180,12 @@ static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
         vgic_add_lr(vcpu, interrupt);
     }
 
-    if (!interrupt->in_lr && vgic_int_has_other_target(vcpu, interrupt)) {
+    /**
+     * An active interrupt cannot be forwarded to another CPU — ownership
+     * cannot be yielded while the interrupt is active, so any IPI would
+     * be silently ignored by the recipient.
+     */
+    if (!interrupt->in_lr && !(interrupt->state & ACT) && vgic_int_has_other_target(vcpu, interrupt)) {
         struct cpu_msg msg = {
             (uint32_t)VGIC_IPI_ID,
             VGIC_ROUTE,

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -146,7 +146,16 @@ void vgic_send_sgi_msg(struct vcpu* vcpu, cpumap_t pcpu_mask, irqid_t int_id)
 
 static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
 {
-    if ((interrupt->state == INV) || !interrupt->enabled) {
+    if (interrupt->state == INV) {
+        return;
+    }
+
+    /**
+     * A disabled interrupt that is still active must be placed in an LR so
+     * the guest can EOI it directly, avoiding an unnecessary LRENP maintenance
+     * interrupt trap.
+     */
+    if (!interrupt->enabled && !(interrupt->state & ACT)) {
         return;
     }
 
@@ -315,7 +324,7 @@ bool vgic_add_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
 {
     bool ret = false;
 
-    if (!interrupt->enabled || interrupt->in_lr) {
+    if ((!interrupt->enabled && !(interrupt->state & ACT)) || interrupt->in_lr) {
         return ret;
     }
 

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -402,7 +402,7 @@ bool vgic_add_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
             }
         }
 
-        if (pend_found > 1) {
+        if (pend_found > 1 && pend_ind >= 0) {
             lr_ind = pend_ind;
         } else {
             lr_ind = act_ind;

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -318,6 +318,16 @@ bool vgic_remove_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
     return ret;
 }
 
+/* Must be called holding vgic_spilled_lock */
+static void vgic_remove_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
+{
+    struct list* spilled_list = gic_is_priv(interrupt->id)
+        ? &vcpu->arch.vgic_spilled
+        : &vcpu->vm->arch.vgic_spilled;
+    list_rm(spilled_list, &interrupt->node);
+    interrupt->in_spilled = false;
+}
+
 static void vgic_spill_lr(struct vcpu* vcpu, size_t lr_ind)
 {
     gic_lr_t lr = (gic_lr_t)gich_read_lr(lr_ind);
@@ -392,6 +402,11 @@ bool vgic_add_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
     }
 
     if (lr_ind >= 0) {
+        if (interrupt->in_spilled) {
+            spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
+            vgic_remove_spilled(vcpu, interrupt);
+            spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+        }
         vgic_write_lr(vcpu, interrupt, (size_t)lr_ind);
         ret = true;
     } else {
@@ -1075,8 +1090,7 @@ void vgic_ipi_handler(uint32_t event, uint64_t data)
 /**
  * Must be called holding the vgic_spilled_lock
  */
-static inline struct vgic_int* vgic_highest_prio_spilled(struct vcpu* vcpu, unsigned flags,
-    struct list** outlist)
+static inline struct vgic_int* vgic_highest_prio_spilled(struct vcpu* vcpu, unsigned flags)
 {
     struct vgic_int* irq = NULL;
     struct list* spilled_lists[] = {
@@ -1098,7 +1112,6 @@ static inline struct vgic_int* vgic_highest_prio_spilled(struct vcpu* vcpu, unsi
             bool is_lower_id = temp_irq->id < irq_id;
             if (is_higher_prio || (is_same_prio && is_lower_id)) {
                 irq = temp_irq;
-                *outlist = list;
             }
         }
     }
@@ -1112,14 +1125,12 @@ static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
     unsigned flags = npie ? PEND : ACT | PEND;
     spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
     while (lr_ind >= 0) {
-        struct list* list = NULL;
-        struct vgic_int* irq = vgic_highest_prio_spilled(vcpu, flags, &list);
+        struct vgic_int* irq = vgic_highest_prio_spilled(vcpu, flags);
         if (irq != NULL) {
             spin_lock(&irq->lock);
             bool got_ownership = vgic_get_ownership(vcpu, irq);
             if (got_ownership) {
-                list_rm(list, &irq->node);
-                irq->in_spilled = false;
+                vgic_remove_spilled(vcpu, irq);
                 vgic_write_lr(vcpu, irq, (size_t)lr_ind);
             }
             spin_unlock(&irq->lock);
@@ -1140,16 +1151,14 @@ static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
 
 static void vgic_eoir_highest_spilled_active(struct vcpu* vcpu)
 {
-    struct list* list = NULL;
     struct vgic_int* interrupt;
 
     spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
-    interrupt = vgic_highest_prio_spilled(vcpu, ACT, &list);
+    interrupt = vgic_highest_prio_spilled(vcpu, ACT);
     if (interrupt != NULL) {
         spin_lock(&interrupt->lock);
         if (vgic_get_ownership(vcpu, interrupt)) {
-            list_rm(list, &interrupt->node);
-            interrupt->in_spilled = false;
+            vgic_remove_spilled(vcpu, interrupt);
         } else {
             spin_unlock(&interrupt->lock);
             interrupt = NULL;

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -144,6 +144,23 @@ void vgic_send_sgi_msg(struct vcpu* vcpu, cpumap_t pcpu_mask, irqid_t int_id)
     }
 }
 
+static void vgic_add_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
+{
+    spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
+    if (!interrupt->in_lr && !interrupt->in_spilled) {
+        struct list* spilled_list = NULL;
+        if (gic_is_priv(interrupt->id)) {
+            spilled_list = &vcpu->arch.vgic_spilled;
+        } else {
+            spilled_list = &vcpu->vm->arch.vgic_spilled;
+        }
+        list_push(spilled_list, (node_t*)interrupt);
+        interrupt->in_spilled = true;
+    }
+    spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+    gich_set_hcr(gich_get_hcr() | GICH_HCR_NPIE_BIT);
+}
+
 static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
 {
     if (interrupt->state == INV) {
@@ -176,6 +193,15 @@ static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
                 cpu_send_msg(i, &msg);
             }
         }
+    }
+
+    /**
+     * If the interrupt was not placed in an LR or forwarded to another CPU,
+     * track it in the spilled list so it gets injected when an LR slot
+     * becomes available.
+     */
+    if (!interrupt->in_lr && !interrupt->in_spilled) {
+        vgic_add_spilled(vcpu, interrupt);
     }
 }
 
@@ -290,20 +316,6 @@ bool vgic_remove_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
     }
 
     return ret;
-}
-
-static void vgic_add_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
-{
-    spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
-    struct list* spilled_list = NULL;
-    if (gic_is_priv(interrupt->id)) {
-        spilled_list = &vcpu->arch.vgic_spilled;
-    } else {
-        spilled_list = &vcpu->vm->arch.vgic_spilled;
-    }
-    list_push(spilled_list, (node_t*)interrupt);
-    spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
-    gich_set_hcr(gich_get_hcr() | GICH_HCR_NPIE_BIT);
 }
 
 static void vgic_spill_lr(struct vcpu* vcpu, size_t lr_ind)
@@ -1107,6 +1119,7 @@ static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
             bool got_ownership = vgic_get_ownership(vcpu, irq);
             if (got_ownership) {
                 list_rm(list, &irq->node);
+                irq->in_spilled = false;
                 vgic_write_lr(vcpu, irq, (size_t)lr_ind);
             }
             spin_unlock(&irq->lock);
@@ -1136,6 +1149,7 @@ static void vgic_eoir_highest_spilled_active(struct vcpu* vcpu)
         spin_lock(&interrupt->lock);
         if (vgic_get_ownership(vcpu, interrupt)) {
             list_rm(list, &interrupt->node);
+            interrupt->in_spilled = false;
         } else {
             spin_unlock(&interrupt->lock);
             interrupt = NULL;

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -1128,18 +1128,28 @@ static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
 static void vgic_eoir_highest_spilled_active(struct vcpu* vcpu)
 {
     struct list* list = NULL;
-    struct vgic_int* interrupt = vgic_highest_prio_spilled(vcpu, ACT, &list);
+    struct vgic_int* interrupt;
 
+    spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
+    interrupt = vgic_highest_prio_spilled(vcpu, ACT, &list);
     if (interrupt != NULL) {
         spin_lock(&interrupt->lock);
         if (vgic_get_ownership(vcpu, interrupt)) {
-            interrupt->state &= (uint8_t)~ACT;
-            if (vgic_int_is_hw(interrupt)) {
-                gic_set_act(interrupt->id, false);
-            } else {
-                if (interrupt->state & PEND) {
-                    vgic_add_lr(vcpu, interrupt);
-                }
+            list_rm(list, &interrupt->node);
+        } else {
+            spin_unlock(&interrupt->lock);
+            interrupt = NULL;
+        }
+    }
+    spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+
+    if (interrupt != NULL) {
+        interrupt->state &= (uint8_t)~ACT;
+        if (vgic_int_is_hw(interrupt)) {
+            gic_set_act(interrupt->id, false);
+        } else {
+            if (interrupt->state & PEND) {
+                vgic_add_lr(vcpu, interrupt);
             }
         }
         spin_unlock(&interrupt->lock);

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -274,10 +274,17 @@ static inline void vgic_write_lr(struct vcpu* vcpu, struct vgic_int* interrupt, 
             lr |= GICH_LR_EOI_BIT;
         }
 
-        lr |= ((gic_lr_t)state << GICH_LR_STATE_OFF) & GICH_LR_STATE_MSK;
+        /**
+         * If the interrupt is disabled, strip PEND from the LR so the guest
+         * only EOIs the active portion and the interrupt is not re-delivered
+         * while disabled. The PEND bit is preserved in interrupt->state so
+         * it is restored when the interrupt is re-enabled.
+         */
+        unsigned lr_state = !interrupt->enabled ? (state & (unsigned)~PEND) : state;
+        lr |= ((gic_lr_t)lr_state << GICH_LR_STATE_OFF) & GICH_LR_STATE_MSK;
     }
 
-    interrupt->state = (uint8_t)INV;
+    interrupt->state = !interrupt->enabled ? (uint8_t)(state & PEND) : (uint8_t)INV;
     interrupt->in_lr = true;
     interrupt->lr = (uint8_t)lr_ind;
     vcpu->arch.vgic_priv.curr_lrs[lr_ind] = interrupt->id;
@@ -301,7 +308,7 @@ bool vgic_remove_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
     interrupt->in_lr = false;
 
     if (GICH_LR_STATE(lr_val) != INV) {
-        interrupt->state = (uint8_t)GICH_LR_STATE(lr_val);
+        interrupt->state = (uint8_t)(GICH_LR_STATE(lr_val) | (interrupt->state & PEND));
 #if (GIC_VERSION == GICV2)
         if (interrupt->id < GIC_MAX_SGIS) {
             if (interrupt->state & ACT) {

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -160,6 +160,15 @@ static void vgic_add_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
         }
         list_push(spilled_list, (node_t*)interrupt);
         interrupt->in_spilled = true;
+    }
+
+    /**
+     * NPIE exists to wake the LR refill when a spilled pending interrupt is
+     * waiting for a slot, so it is armed based on the interrupt's pending
+     * state rather than on the insertion: an already spilled active interrupt
+     * that just became pending must arm it as well.
+     */
+    if (interrupt->in_spilled && ((vgic_get_state(interrupt) & PEND) != 0U)) {
         gich_set_hcr(gich_get_hcr() | GICH_HCR_NPIE_BIT);
     }
     spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -144,6 +144,10 @@ void vgic_send_sgi_msg(struct vcpu* vcpu, cpumap_t pcpu_mask, irqid_t int_id)
     }
 }
 
+/**
+ * Track an interrupt that could not be placed in an LR so it gets injected
+ * when an LR slot becomes available.
+ */
 static void vgic_add_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
 {
     spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
@@ -156,9 +160,9 @@ static void vgic_add_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
         }
         list_push(spilled_list, (node_t*)interrupt);
         interrupt->in_spilled = true;
+        gich_set_hcr(gich_get_hcr() | GICH_HCR_NPIE_BIT);
     }
     spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
-    gich_set_hcr(gich_get_hcr() | GICH_HCR_NPIE_BIT);
 }
 
 static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
@@ -185,7 +189,9 @@ static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
      * cannot be yielded while the interrupt is active, so any IPI would
      * be silently ignored by the recipient.
      */
-    if (!interrupt->in_lr && !(interrupt->state & ACT) && vgic_int_has_other_target(vcpu, interrupt)) {
+    bool forwarded = false;
+    if (!interrupt->in_lr && !(interrupt->state & ACT) &&
+        vgic_int_has_other_target(vcpu, interrupt)) {
         struct cpu_msg msg = {
             (uint32_t)VGIC_IPI_ID,
             VGIC_ROUTE,
@@ -196,16 +202,12 @@ static void vgic_route(struct vcpu* vcpu, struct vgic_int* interrupt)
         for (size_t i = 0; i < platform.cpu_num; i++) {
             if (trgtlist & (1ULL << i)) {
                 cpu_send_msg(i, &msg);
+                forwarded = true;
             }
         }
     }
 
-    /**
-     * If the interrupt was not placed in an LR or forwarded to another CPU,
-     * track it in the spilled list so it gets injected when an LR slot
-     * becomes available.
-     */
-    if (!interrupt->in_lr && !interrupt->in_spilled) {
+    if (!interrupt->in_lr && !forwarded) {
         vgic_add_spilled(vcpu, interrupt);
     }
 }
@@ -333,9 +335,8 @@ bool vgic_remove_lr(struct vcpu* vcpu, struct vgic_int* interrupt)
 /* Must be called holding vgic_spilled_lock */
 static void vgic_remove_spilled(struct vcpu* vcpu, struct vgic_int* interrupt)
 {
-    struct list* spilled_list = gic_is_priv(interrupt->id)
-        ? &vcpu->arch.vgic_spilled
-        : &vcpu->vm->arch.vgic_spilled;
+    struct list* spilled_list =
+        gic_is_priv(interrupt->id) ? &vcpu->arch.vgic_spilled : &vcpu->vm->arch.vgic_spilled;
     list_rm(spilled_list, &interrupt->node);
     interrupt->in_spilled = false;
 }

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -1140,21 +1140,73 @@ static inline struct vgic_int* vgic_highest_prio_spilled(struct vcpu* vcpu, unsi
     return irq;
 }
 
+/**
+ * Spills the active only LR with the lowest priority (highest ID on a tie) to
+ * free a slot, returning its index, or -1 if no LR holds an active only entry.
+ */
+static ssize_t vgic_spill_lowest_prio_active_lr(struct vcpu* vcpu)
+{
+    ssize_t lr_ind = -1;
+    unsigned max_prio = 0;
+    irqid_t max_id = 0;
+
+    for (size_t i = 0; i < NUM_LRS; i++) {
+        gic_lr_t lr = (gic_lr_t)gich_read_lr(i);
+        gic_lr_t lr_state = lr & GICH_LR_STATE_MSK;
+        unsigned lr_prio = (unsigned)((lr & GICH_LR_PRIO_MSK) >> GICH_LR_PRIO_OFF);
+        irqid_t lr_id = (irqid_t)GICH_LR_VID(lr);
+        if ((lr_state == GICH_LR_STATE_ACT) &&
+            ((lr_ind < 0) || (lr_prio > max_prio) || ((lr_prio == max_prio) && (lr_id > max_id)))) {
+            lr_ind = (ssize_t)i;
+            max_prio = lr_prio;
+            max_id = lr_id;
+        }
+    }
+
+    if (lr_ind >= 0) {
+        vgic_spill_lr(vcpu, (size_t)lr_ind);
+    }
+
+    return lr_ind;
+}
+
 static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
 {
-    uint64_t elrsr = gich_get_elrsr();
-    ssize_t lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
     unsigned flags = npie ? PEND : ACT | PEND;
-    while (lr_ind >= 0) {
+    bool done = false;
+    while (!done) {
         spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
         struct vgic_int* irq = vgic_highest_prio_spilled(vcpu, flags);
         if (irq == NULL) {
             uint32_t hcr = gich_get_hcr();
             gich_set_hcr(hcr & ~(GICH_HCR_NPIE_BIT | GICH_HCR_UIE_BIT));
             spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
-            break;
+            done = true;
+            continue;
         }
         spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+
+        uint64_t elrsr = gich_get_elrsr();
+        ssize_t lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
+        if (lr_ind < 0) {
+            /**
+             * No free LR. If this refill is here to deliver a pending
+             * interrupt (the NP condition means none is resident), a slot
+             * must be freed by spilling an active LR: leaving no pending
+             * resident would keep the level sensitive NP maintenance
+             * asserted forever, never letting the guest run to EOI. The
+             * spilled active's EOI is served by the EOICount/LRENP
+             * machinery, and the guest's preemption level is unaffected
+             * as it is tracked by GICH_APR, not by the LR.
+             */
+            if (flags == (unsigned)PEND) {
+                lr_ind = vgic_spill_lowest_prio_active_lr(vcpu);
+            }
+            if (lr_ind < 0) {
+                done = true;
+                continue;
+            }
+        }
 
         /**
          * The candidate was picked without holding its lock, so between the
@@ -1179,8 +1231,6 @@ static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
         if (eligible) {
             vgic_write_lr(vcpu, irq, (size_t)lr_ind);
             flags = ACT | PEND;
-            elrsr = gich_get_elrsr();
-            lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
         }
         spin_unlock(&irq->lock);
     }

--- a/src/arch/armv8/vgic.c
+++ b/src/arch/armv8/vgic.c
@@ -1136,59 +1136,85 @@ static void vgic_refill_lrs(struct vcpu* vcpu, bool npie)
     uint64_t elrsr = gich_get_elrsr();
     ssize_t lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
     unsigned flags = npie ? PEND : ACT | PEND;
-    spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
     while (lr_ind >= 0) {
+        spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
         struct vgic_int* irq = vgic_highest_prio_spilled(vcpu, flags);
-        if (irq != NULL) {
-            spin_lock(&irq->lock);
-            bool got_ownership = vgic_get_ownership(vcpu, irq);
-            if (got_ownership) {
-                vgic_remove_spilled(vcpu, irq);
-                vgic_write_lr(vcpu, irq, (size_t)lr_ind);
-            }
-            spin_unlock(&irq->lock);
-            if (!got_ownership) {
-                continue;
-            }
-        } else {
+        if (irq == NULL) {
             uint32_t hcr = gich_get_hcr();
             gich_set_hcr(hcr & ~(GICH_HCR_NPIE_BIT | GICH_HCR_UIE_BIT));
+            spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
             break;
         }
-        flags = ACT | PEND;
-        elrsr = gich_get_elrsr();
-        lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
+        spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+
+        /**
+         * The candidate was picked without holding its lock, so between the
+         * list walk and locking it here it may have left the list or changed
+         * state. Revalidate under both locks, taken in the canonical order
+         * (interrupt lock first, spilled lock inside), and rescan if it is
+         * no longer an eligible candidate.
+         */
+        spin_lock(&irq->lock);
+        spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
+        bool eligible = irq->in_spilled && ((vgic_get_state(irq) & flags) != 0) &&
+            vgic_get_ownership(vcpu, irq);
+        if (eligible) {
+            vgic_remove_spilled(vcpu, irq);
+        }
+        spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+        /**
+         * Writing the LR may take the previous occupant's interrupt lock, so
+         * it must happen after the spilled lock is released to preserve the
+         * canonical lock order.
+         */
+        if (eligible) {
+            vgic_write_lr(vcpu, irq, (size_t)lr_ind);
+            flags = ACT | PEND;
+            elrsr = gich_get_elrsr();
+            lr_ind = bit64_ffs(elrsr & BIT64_MASK(0, NUM_LRS));
+        }
+        spin_unlock(&irq->lock);
     }
-    spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
 }
 
 static void vgic_eoir_highest_spilled_active(struct vcpu* vcpu)
 {
-    struct vgic_int* interrupt;
+    bool done = false;
 
-    spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
-    interrupt = vgic_highest_prio_spilled(vcpu, ACT);
-    if (interrupt != NULL) {
-        spin_lock(&interrupt->lock);
-        if (vgic_get_ownership(vcpu, interrupt)) {
-            vgic_remove_spilled(vcpu, interrupt);
-        } else {
-            spin_unlock(&interrupt->lock);
-            interrupt = NULL;
-        }
-    }
-    spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+    while (!done) {
+        spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
+        struct vgic_int* interrupt = vgic_highest_prio_spilled(vcpu, ACT);
+        spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
 
-    if (interrupt != NULL) {
-        interrupt->state &= (uint8_t)~ACT;
-        if (vgic_int_is_hw(interrupt)) {
-            gic_set_act(interrupt->id, false);
+        if (interrupt == NULL) {
+            done = true;
         } else {
-            if (interrupt->state & PEND) {
-                vgic_add_lr(vcpu, interrupt);
+            /**
+             * As in vgic_refill_lrs, the candidate was picked without holding
+             * its lock; revalidate it under both locks in the canonical order
+             * and rescan if it raced off the list.
+             */
+            spin_lock(&interrupt->lock);
+            spin_lock(&vcpu->vm->arch.vgic_spilled_lock);
+            bool listed = interrupt->in_spilled && ((vgic_get_state(interrupt) & ACT) != 0);
+            bool eligible = listed && vgic_get_ownership(vcpu, interrupt);
+            if (eligible) {
+                vgic_remove_spilled(vcpu, interrupt);
             }
+            spin_unlock(&vcpu->vm->arch.vgic_spilled_lock);
+            if (eligible) {
+                interrupt->state &= (uint8_t)~ACT;
+                if (vgic_int_is_hw(interrupt)) {
+                    gic_set_act(interrupt->id, false);
+                } else {
+                    if (interrupt->state & PEND) {
+                        vgic_add_lr(vcpu, interrupt);
+                    }
+                }
+            }
+            spin_unlock(&interrupt->lock);
+            done = listed;
         }
-        spin_unlock(&interrupt->lock);
     }
 }
 


### PR DESCRIPTION
Based on top of #334; only the last two commits are new, will rebase once it merges.

The NP maintenance condition is level sensitive: it stays asserted while NPIE is set and no list register holds a pending interrupt. If every LR is occupied by an active interrupt (guest acknowledged them all, e.g. nested handlers) while a pending interrupt sits on the spilled list, vgic_refill_lrs finds no free LR, so it neither injects the pending interrupt nor clears NPIE, and the maintenance interrupt re-asserts immediately on guest entry. The guest, the only agent that can free an LR by EOIing an active, never runs again: the VM livelocks. Reachable with guest interrupt nesting depth equal to the number of LRs (4 on GICv2 implementations like GIC-400) plus one more, lower priority, pending interrupt.

The fix restructures the refill to pick the delivery candidate before requiring a free LR, so the nothing-to-deliver path clears NPIE even with all LRs in use, and, when there is a pending candidate but no free LR, spills the lowest priority active LR to make room. This keeps the spec's recommendation of at least one resident pending interrupt (IHI 0048B.b 5.2.1) unconditional. The evicted active's EOI is handled by the existing EOICount/LRENP path, and the guest's preemption level is untouched since it is tracked by GICH_APR, not by the LR. A first commit re-keys NPIE arming on a pending interrupt actually sitting on the spilled list, so active only spills no longer arm it and a spilled active that later becomes pending does.
