### PR TITLE
fix(lib/list): update the tail when removing the last node

### DIFF
--- a/src/lib/inc/list.h
+++ b/src/lib/inc/list.h
@@ -107,8 +107,8 @@ static inline bool list_rm(struct list* list, node_t* node)
                 list->head = *temp;
             }
 
-            if (list->head == NULL) {
-                list->tail = NULL;
+            if (list->tail == node) {
+                list->tail = temp_prev;
             }
         }
 


### PR DESCRIPTION
`list_rm` only reset `list->tail` when the list became empty. When the removed node was the tail of a list that stayed non-empty, the tail kept pointing at the removed node, so the next `list_push` linked the new node through a node that was no longer in the list, leaving the new node unreachable from the head.

The vgic spilled lists are affected: `vgic_refill_lrs` removes the highest-priority spilled interrupt and the spill path pushes new ones onto the same list. Whenever the removed interrupt happened to be the tail, the next spilled interrupt was lost, i.e. a pending interrupt that was never delivered. This needs more pending interrupts than list registers, so it shows up under LR pressure.

The fix updates the tail to the predecessor whenever the removed node is the tail, which also covers the single-element case that the previous check handled.